### PR TITLE
fix twice change event

### DIFF
--- a/src/components/Checklist.vue
+++ b/src/components/Checklist.vue
@@ -109,11 +109,6 @@ export default {
   data () {
     return {
     }
-  },
-  watch: {
-    value (newVal) {
-      this.$dispatch('change', this.value)
-    }
   }
 }
 </script>


### PR DESCRIPTION
修复checklist的change事件会在demo中调用两次的问题。与之前XButton调用两次点击事件同理。