### PR TITLE
修正Number组件最大或最小值设置为0时无效的BUG

### DIFF
--- a/src/components/number/index.vue
+++ b/src/components/number/index.vue
@@ -84,10 +84,10 @@ export default {
   },
   computed: {
     disabled_min: function () {
-      return !this.min ? false : this.value <= this.min
+      return typeof this.min === 'undefined' ? false : this.value <= this.min
     },
     disabled_max: function () {
-      return !this.max ? false : this.value >= this.max
+      return typeof this.max === 'undefined' ? false : this.value >= this.max
     }
   },
   ready: function () {


### PR DESCRIPTION
修复前bug表现为，当number组件的min或max属性设置为0时，无法达到预期结果。
会出现实际值小于最小值或者大于最大值的情况。