### PR TITLE
100%宽度导致后面的箭头看不见

### DIFF
--- a/src/components/popup-picker/index.vue
+++ b/src/components/popup-picker/index.vue
@@ -86,6 +86,5 @@ export default {
 }
 .vux-popup-picker-value {
   display: inline-block;
-  width: 100%;
 }
 </style>


### PR DESCRIPTION
.vux-popup-picker-value 100%宽度删除