### PR TITLE
Scroller: support recovery pullup plugin

### DIFF
--- a/src/components/scroller/index.vue
+++ b/src/components/scroller/index.vue
@@ -174,6 +174,7 @@ export default {
       // if use slot=pullup
       let container = this.$el.querySelector('div[slot="pullup"]')
       let config = Object.assign(pullupDefaultConfig(), this.pullupConfig)
+
       if (container) {
         config.container = container
       }
@@ -227,7 +228,9 @@ export default {
       }
     },
     'pullup:done': function (uuid) {
-      this._xscroll.unplug(this.pullup)
+      if (uuid === this.uuid) {
+        this._xscroll.unplug(this.pullup)
+      }
     },
     'scroller:reset': function (uuid) {
       if (uuid === this.uuid) {


### PR DESCRIPTION
支持重新挂载pullup插件。

使用场景是：

当页面只有一页的数据时，会`broadcast` `pullup:done` 将插件卸载。

当下拉刷新后，有数据新增，且页数超过了1页，那么希望重新挂载上拉刷新组件