### PR TITLE
bug-fix：timepicker Safari下初始化窗口后渐变无效 微信浏览器内显示隐藏动画错误

### DIFF
--- a/src/components/datetime/datetimepicker.js
+++ b/src/components/datetime/datetimepicker.js
@@ -279,6 +279,7 @@ DatetimePicker.prototype = {
   hide: function () {
     var self = this
     self.container.style.removeProperty('transform')
+    self.container.style.removeProperty('-webkit-transform')
 
     setTimeout(function () {
       self.container.style.display = 'none'

--- a/src/components/datetime/index.vue
+++ b/src/components/datetime/index.vue
@@ -141,7 +141,7 @@ export default {
   left: 0;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: -1;
 }
 
 .scroller-mask {


### PR DESCRIPTION
1. 把scroller-content的z-index设为-1可以正确显示background-image的渐变效果（Safari的锅）
2. 在隐藏的时候需要把-webkit-transform也remove了。不然在安卓的微信浏览器内会没有动画