### PR TITLE
add z-index in search of components

### DIFF
--- a/src/components/search/index.vue
+++ b/src/components/search/index.vue
@@ -108,6 +108,7 @@ export default {
   height: 100%;
   left: 0;
   top: 0;
+  z-index: 5;
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(5px);
 }


### PR DESCRIPTION
因.weui_select有设置z-index为1，导致.vux-search-fixed的z轴反而低于.weui_select,会导致不能保证遮罩完全。z-index取5是参照.vux-search-mask,非必须，>=1皆可。
