### PR TITLE
XImg: used emit instead of dispatch, and fixed event naming

### DIFF
--- a/src/components/x-img/index.vue
+++ b/src/components/x-img/index.vue
@@ -26,10 +26,10 @@ export default {
       errorClass: _this.errorClass,
       successClass: _this.successClass,
       success (ele) {
-        _this.$dispatch('success', _this.src, ele)
+        _this.$emit('on-success', _this.src, ele)
       },
       error (ele, msg) {
-        _this.$dispatch('error', _this.src, ele, msg)
+        _this.$emit('on-error', _this.src, ele, msg)
       }
     })
   },

--- a/src/demos/XImg.vue
+++ b/src/demos/XImg.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-for="src in list" style="background-color:yellow;text-align:center;">
       <span style="font-size:20px;">Loading</span>
-      <x-img :src="src" @success="success" @error="error" class="ximg-demo" error-class="ximg-error" :offset="-300"></x-img>
+      <x-img :src="src" @on-success="success" @on-error="error" class="ximg-demo" error-class="ximg-error" :offset="-300"></x-img>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Related #151

* 使用emit代替disptch
* 根据事件命名规范，修改了事件命名
* 更新了相应的Demo

@airyland Pls take a look, If it is ok, wil be merged.