### PR TITLE
Update rater components

### DIFF
--- a/src/components/rater/index.vue
+++ b/src/components/rater/index.vue
@@ -18,8 +18,7 @@ export default {
     },
     value: {
       type: Number,
-      default: 0,
-      twoWay: true
+      default: 0
     },
     disabled: {
       type: Boolean,


### PR DESCRIPTION
Statistically in more than a half situations, rater components are used as merely an presenting method. So there's no need of the value property of rater components to be set as two-way binding. Further more, if the value passed to a rater components from its parent components is a computed value or a value using filter, which might happen in some cliche system, `Vue` will throw out a warn error as follows:
`vconsole.min.js:6 [Vue warn]: Cannot bind two-way prop with non-settable parent path: parseInt(store.rate) (found in component: <rater>)`
Though this error will be hidden in production version of `Vue`, I think it should be issued in the component source level.