### PR TITLE
Remove static line height of rater

### DIFF
--- a/src/components/rater/index.vue
+++ b/src/components/rater/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vux-rater">
-    <a class="vux-rater-box" v-for="i in max" @click="handleClick(i)" :class="{'is-active':value > i}" :style="{color: colors && colors[i] ? colors[i] : '#ccc',marginRight:margin+'px',fontSize: fontSize + 'px', width: fontSize + 'px', height: fontSize + 'px'}">
+    <a class="vux-rater-box" v-for="i in max" @click="handleClick(i)" :class="{'is-active':value > i}" :style="{color: colors && colors[i] ? colors[i] : '#ccc',marginRight:margin+'px',fontSize: fontSize + 'px', width: fontSize + 'px', height: fontSize + 'px', lineHeight: fontSize + 'px'}">
       <span class="vux-rater-inner">{{star}}<span class="vux-rater-outer" :style="{color: activeColor, width: cutPercent + '%'}" v-if="cutPercent > 0 && cutIndex === i">{{star}}</span></span>
     </a>
   </div>
@@ -98,7 +98,6 @@ export default {
 .vux-rater a {
   display: inline-block;
   text-align: center;
-  line-height: 25px;
   cursor: pointer;
   color: #ccc;
 }


### PR DESCRIPTION
The line height of a rater a element should be adjusted as a function of its height and font size, not fixed as 25px. Otherwise if people use a different font size, vertical position of the rater character may be affected and incur some unexpected behavior.