### PR TITLE
Add a large z-index value

### DIFF
--- a/src/components/sticky/index.vue
+++ b/src/components/sticky/index.vue
@@ -17,6 +17,7 @@ export default {
   width: 100%;
   position: sticky;
   top: 0;
+  z-index:9999;
 }
 .vux-fixed {
   width: 100%;


### PR DESCRIPTION
If something is sticky, it should be expected to show on the screen all the time. So its z-index value should be relatively larger than all of other element. I hereby set it to 9999.