### PR TITLE
修复 Toast 文本模式下 最小高度问题

### DIFF
--- a/src/components/toast/index.vue
+++ b/src/components/toast/index.vue
@@ -64,7 +64,7 @@ export default {
   color: #F76260;
 }
 .weui_toast.weui_toast_text{
-  min-height: auto;
+  min-height: 0;
 }
 .weui_toast_text .weui_toast_content {
   margin: 0;


### PR DESCRIPTION
测试在 iOS 下 微信内核浏览器，Safari浏览器，Toast 组件设置文本模式 Toast 提示框有最小高度值的问题，

具体可看官网 Demo https://vux.li/?x-page=github_readme#!/component/toast  （请用手机浏览 文字提示）