### PR TITLE
title为空时隐藏div

### DIFF
--- a/src/components/checklist/index.vue
+++ b/src/components/checklist/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="weui_cells_title">{{title}}</div>
+  <div v-show="title" class="weui_cells_title">{{title}}</div>
   <div class="weui_cells weui_cells_checkbox">
     <label class="weui_cell weui_check_label" for="checkbox_{{uuid}}_{{index}}" v-for="(index,one) in options">
       <div class="weui_cell_hd">


### PR DESCRIPTION
checklist的title为空时,不显示<div class="weui_cells_title">{{title}}</div>
因为weui_cells_title样式中的margin会让该div显示在页面上.