### PR TITLE
添加.weui_btn_area外部间隔

### DIFF
--- a/src/components/x-button/index.vue
+++ b/src/components/x-button/index.vue
@@ -1,7 +1,9 @@
 <template>
-  <button class="weui_btn" :class="classes" :disabled="disabled">
-    {{text}}<slot></slot>
-  </button>
+  <div class="weui_btn_area">
+    <button class="weui_btn" :class="classes" :disabled="disabled">
+      {{text}}<slot></slot>
+    </button>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
既然x-input、x-textarea、x-number都是基于cell的，那这个x-button我们是不是也应该这么去理解，所以应该默认加上.weui_btn_area的外框。