### PR TITLE
修复inline calendar组件data-date字段计算错误的问题

### DIFF
--- a/src/components/inline-calendar/index.vue
+++ b/src/components/inline-calendar/index.vue
@@ -120,7 +120,7 @@ export default {
       this.month = data.month
     },
     formatDate: (year, month, child) => {
-      return [year, zero(month + 1), zero(child.day)].join('-')
+      return [year, zero(child.month + 1), zero(child.day)].join('-')
     },
     prev () {
       if (this.month === 0) {


### PR DESCRIPTION
日期单元格的data-date非当月的日期会计算成当月，例如当月是2016-08，日历7月份
那最后几天的data-date字段会显示为2016-08-xx，会造成replaceText时同一个月出现两个today。