### PR TITLE
x-textarea总字数计算中考虑文本框当前值为空或未定义情况

### DIFF
--- a/src/components/x-textarea/index.vue
+++ b/src/components/x-textarea/index.vue
@@ -62,7 +62,10 @@ export default {
   },
   computed: {
     count () {
-      let len = this.value.replace(/\n/g, 'aa').length
+      let len = 0
+      if (this.value) {
+        len = this.value.replace(/\n/g, 'aa').length
+      }
       return len > this.max ? this.max : len
     },
     textareaStyle () {


### PR DESCRIPTION
```html
<x-textarea :value="textValue" :max="100"></x-textarea>
```
如上情况下，当 textValue 为 null 时，计算总字数时会报错，因为出现 null.length。虽然可以使用过滤器或者其它手段在自身业务中解决这一问题，但我觉得组件内部解决会方便更多人。
