### PR TITLE
fix: 使用tab, 且tab-item为动态生成时切换菜单报错

### DIFF
--- a/src/mixins/multi-items.js
+++ b/src/mixins/multi-items.js
@@ -23,7 +23,7 @@ const parentMixin = {
   },
   watch: {
     index (val, oldVal) {
-      oldVal > -1 && (this.$children[oldVal].selected = false)
+      oldVal > -1 && this.$children[oldVal] && (this.$children[oldVal].selected = false)
       this.$children[val].selected = true
     }
   },


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors

使用 tab 组件和 tab-item 动态生成子导航

```
<tab>
  <tab-item>
  <tab-item>
  <tab-item>
</tab>

<tabbar>
  <tabbar-item> // tabbar-item 1
  <tabbar-item>
</tabbar>
```

```
<tab>
  <tab-item>
  <tab-item>
</tab>

<tabbar>
  <tabbar-item>
  <tabbar-item> // tabbar-item 2
</tabbar>
```

当从 tabbar-item 1 切换至 tabbar-item 2时，tab 中 tab-item 减少了 一项，此时 oldVal = 2, this.$children.length 为 2, 导致报错

**Uncaught TypeError: Cannot set property 'selected' of undefined**