### PR TITLE
对于checklist里面的最多最少选择个数和是否是required的一点建议

### DIFF
--- a/src/components/checklist/index.vue
+++ b/src/components/checklist/index.vue
@@ -61,44 +61,29 @@ export default {
       return this.fillMode ? (this.options.length + 1) : this.options.length
     },
     _min () {
-      if (!this.required) {
-        return 0
-      }
-      if (this.min) {
-        if (this.min < 0) {
-          return 1
-        }
-        if (this.min >= this._total) {
-          return this._total
-        }
-        return this.min
+      if (this.min > 0) {
+        return Math.min(this.min, this._total)
       } else {
-        return 1
+        return this.required ? 1 : 0
       }
     },
     _max () {
-      if (!this.required) {
-        return this._total
-      }
-      if (this.max) {
-        if (this.max > this._total) {
-          return this._total
-        }
-        return this.max
+      if (this.max > 0) {
+        return Math.min(this.max, this._total)
       } else {
         return this._total
       }
     },
     valid () {
-      return this.value.length >= this._min && this.value.length <= this._max
+      return !(this.value.length || this.required) || (this.value.length >= this._min && this.value.length <= this._max)
     },
     error () {
       let err = []
       if (this.value.length < this._min) {
-        err.push(this.$interpolate('最少要选择{{_min}}个哦'))
+        err.push(this.$interpolate('最少要选择{{_min}}个哦' + (this.required ? '' : ',或者不选择')))
       }
       if (this.value.length > this._max) {
-        err.push(this.$interpolate('最多只能选择{{_max}}个哦'))
+        err.push(this.$interpolate('最多只能选择{{_max}}个哦' + (this.required ? '' : ',或者不选择')))
       }
       return err
     }


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!
- [ ] `Rebase` before creating a PR to keep commit history clear.
- [ ] `Only One commit`
- [ ] No `eslint` errors

对于checklist里面的最多最少选择个数和是否是required的一点建议
当前情况，当required为false时，最多选择个数将失效，最少也是类似情况
我认为required控制是否需要选择，而max和min控制的是再选择的情况下个数的控制，二者不应该有干扰。比如表单中有爱好项，用户可以不选择，但是选择是话最多只能选择三个爱好，最少类似
每个人理解可能不一样，提上我的修复，请考虑一下
