### PR TITLE
Fix actionsheet invalid default value warning

### DIFF
--- a/src/components/actionsheet/index.vue
+++ b/src/components/actionsheet/index.vue
@@ -30,7 +30,7 @@ export default {
     },
     menus: {
       type: Object,
-      default: {}
+      default: () => {}
     }
   },
   methods: {


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors

Fix warning:

```
[Vue warn]: Invalid default value for prop "menus": Props with type Object/Array must use a factory function to return the default value. (found in component: <actionsheet>)
```

Discussion: https://github.com/vuejs/vue/issues/1032