### PR TITLE
fix bug and code tidy

### DIFF
--- a/src/components/dialog/index.vue
+++ b/src/components/dialog/index.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="weui_dialog_alert" @touchmove="!this.scroll && $event.preventDefault()">
-    <div class="weui_mask" @click="hideOnBlur && (show = false)" v-show="show" :transition="maskTransition"></div>
-    <div class="weui_dialog" v-show="show" :transition="dialogTransition">
+  <div class="weui_dialog_alert" v-show="show">
+    <div class="weui_mask" @click="this.hideOnBlur && (this.show = false)" :transition="maskTransition"></div>
+    <div class="weui_dialog" :transition="dialogTransition">
       <slot></slot>
     </div>
   </div>
@@ -22,10 +22,9 @@ export default {
       type: String,
       default: 'vux-dialog'
     },
-    hideOnBlur: Boolean,
-    scroll: {
+    hideOnBlur: {
       type: Boolean,
-      default: true
+      default: false
     }
   },
   watch: {

--- a/src/components/dialog/index.vue
+++ b/src/components/dialog/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="weui_dialog_alert" v-show="show">
-    <div class="weui_mask" @click="this.hideOnBlur && (this.show = false)" :transition="maskTransition"></div>
+    <div class="weui_mask" @click="hideOnBlur && (show = false)" :transition="maskTransition"></div>
     <div class="weui_dialog" :transition="dialogTransition">
       <slot></slot>
     </div>


### PR DESCRIPTION
1. remove  @touchmove="!this.scroll && $event.preventDefault()" fragment as it doesn't work as expected, becuase there's no corresponding style for 'weui_dialog_alert', in fact it's {width: auto;height:0}, can not be touched, and 'weui_mask' 'weui_dialog' both are set as position:fixed. so touchmove can never work
2. move v-show to parent node