### PR TITLE
Switch component only emit the change event only by user click action

### DIFF
--- a/src/components/switch/index.vue
+++ b/src/components/switch/index.vue
@@ -5,7 +5,7 @@
       <inline-desc v-if="inlineDesc">{{inlineDesc}}</inline-desc>
     </div>
     <div class="weui_cell_ft">
-      <input class="weui_switch" type="checkbox" :disabled="disabled" v-model="value"/>
+      <input class="weui_switch" type="checkbox" :disabled="disabled" v-model="value" @click="toggle"/>
     </div>
   </div>
 </template>
@@ -16,6 +16,11 @@ import InlineDesc from '../inline-desc'
 export default {
   components: {
     InlineDesc
+  },
+  methods: {
+    toggle () {
+      this.$emit('on-change', this.value)
+    }
   },
   computed: {
     labelStyle () {
@@ -37,11 +42,6 @@ export default {
       default: false
     },
     inlineDesc: String
-  },
-  watch: {
-    value (newVal) {
-      this.$emit('on-change', newVal)
-    }
   }
 }
 </script>


### PR DESCRIPTION
switch组件emit的change事件，我理解应该只来源于用户的行为，原来使用的是watch方式并不是很合适，举个例子：用户点击行为导致的switch值变化需要提交请求，异步获取的值触发switch emit 的on-change事件会循环调用。不知道我讲清楚没有 @airyland 

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors

