### PR TITLE
popover:fix #756,#734

### DIFF
--- a/src/components/popup/index.vue
+++ b/src/components/popup/index.vue
@@ -88,7 +88,7 @@ export default {
 </script>
 
 <style>
-.vux-popup-dialog {
+.vux-popup-dialog,.vux-popup {
   position: fixed;
   left: 0;
   bottom: 0;

--- a/src/components/popup/popup.js
+++ b/src/components/popup/popup.js
@@ -56,6 +56,11 @@ popupDialog.prototype._bindEvents = function () {
 popupDialog.prototype.show = function () {
   this.mask.classList.add('vux-popup-show')
   this.container.classList.add('vux-popup-show')
+  if (this.container.classList.contains('vux-popup')) {
+    this.container.classList.remove('vux-popup')
+    this.container.classList.add('vux-popup-dialog')
+    this.container.classList.add('vux-popup-dialog' + this.uuid)
+  }
   this.params.onOpen && this.params.onOpen(this)
   this.isShow = true
   window.__$vuxPopups[this.uuid] = 1
@@ -65,6 +70,11 @@ popupDialog.prototype.hide = function (shouldCallback = true) {
   this.container.classList.remove('vux-popup-show')
   if (!document.querySelector('.vux-popup-dialog.vux-popup-show')) {
     this.mask.classList.remove('vux-popup-show')
+  }
+  if (this.container.classList.contains('vux-popup')) {
+    this.container.classList.remove('vux-popup')
+    this.container.classList.add('vux-popup-dialog')
+    this.container.classList.add('vux-popup-dialog' + this.uuid)
   }
   shouldCallback === false && this.params.onClose && this.params.hideOnBlur && this.params.onClose(this)
   this.isShow = false


### PR DESCRIPTION
这两个bug的成因类似，都是一个popover的class从vux-popup-dialog变成了vux-popup。很诡异，我看了源码，classList.remove应该不会导致这个bug的。没法从根源解决，就把这个vux-popup也设置成和vux-popup-dialog相同的样式，再在每次出现后去检测，把class改回来。亲测这两个bug从现象上都消失了，当然变成了vux-popup的根源还没研究出来