### PR TITLE
fix extra option when prop value is 0 in ios

### DIFF
--- a/src/components/selector/index.vue
+++ b/src/components/selector/index.vue
@@ -5,8 +5,8 @@
     </div>
     <div class="weui-cell__bd" v-if="!readonly">
       <select class="weui-select" v-model="currentValue" :style="{direction: direction}">
-        <option value="" v-if="!value && placeholder" :selected="!value && placeholder">{{placeholder}}</option>
-        <option disabled v-if="!placeholder && !value && isIOS && title"></option>
+        <option value="" v-if="typeof value === 'undefined' && placeholder" :selected="typeof value === 'undefined' && placeholder">{{placeholder}}</option>
+        <option disabled v-if="!placeholder && typeof value === 'undefined' && isIOS && title"></option>
         <option :value="one.key" v-for="one in processOptions">{{one.value}}</option>
       </select>
     </div>
@@ -28,7 +28,7 @@ const findByKey = function (key, options) {
 
 export default {
   created () {
-    if (this.value) {
+    if (typeof value !== 'undefined') {
       this.currentValue = this.value
     }
   },


### PR DESCRIPTION
when prop value is 0, which common,  if in ios,  Selector can not find the right option。
当prop是0的时候，ios下会出现一个多余的option并处于选定状态，但实际应选定的option没选定。

PR把所有的 !value 改成了 typeof value === 'undefined'，实际使用测试通过，run components也试过没问题