### PR TITLE
fix align problem when x-number is readonly

### DIFF
--- a/src/components/x-number/index.vue
+++ b/src/components/x-number/index.vue
@@ -14,7 +14,7 @@
         </a>
       </div>
     </div>
-    <div class="weui-cell__ft" v-show="readonly">
+    <div class="weui-cell__ft vux-cell-primary" v-show="readonly">
       {{value}}
     </div>
   </div>


### PR DESCRIPTION
当x-number为readonly的时候，x-number的数字并不是靠右位置。 这导致x-number变成readonly的时候，数字位置会跳动。