### PR TITLE
show actionsheet when prop value is true initially

### DIFF
--- a/src/components/actionsheet/index.vue
+++ b/src/components/actionsheet/index.vue
@@ -85,8 +85,11 @@ export default {
         }, 200)
       }
     },
-    value (val) {
-      this.show = val
+    value: {
+      handler: function (val) {
+        this.show = val
+      },
+      immediate: true
     }
   },
   beforeDestroy () {


### PR DESCRIPTION
当action的props参数value的初始值为true的时候，actionsheet并没有显示在页面上。
在watch value的时候加上immediate参数即可解决。
当然也可以使用之前的方式，created里面判断value的值，但使用immediate更合理一些