### PR TITLE
trigger focus event of textarea when click counter

### DIFF
--- a/src/components/x-textarea/index.vue
+++ b/src/components/x-textarea/index.vue
@@ -27,7 +27,7 @@
         :style="textareaStyle"
         :maxlength="max"
         ref="textarea"></textarea>
-      <div class="weui-textarea-counter" v-show="showCounter && max"><span>{{count}}</span>/{{max}}</div>
+      <div class="weui-textarea-counter" v-show="showCounter && max" @click="focus"><span>{{count}}</span>/{{max}}</div>
     </div>
   </div>
 </template>
@@ -139,6 +139,11 @@
       },
       labelWidth () {
         return this.title.replace(/[^x00-xff]/g, '00').length / 2 + 1
+      }
+    },
+    methods: {
+      focus () {
+        this.$refs.textarea.focus()
       }
     }
   }

--- a/src/components/x-textarea/metas.yml
+++ b/src/components/x-textarea/metas.yml
@@ -86,6 +86,11 @@ events:
     en: blur event
     zh-CN: blur 事件
 changes:
+  next:
+    en:
+      - '[enhance] trigger focus event of x-textarea when click counter'
+    zh-CN:
+      - '[enhance] 点击x-textarea的counter时，主动触发focus事件'
   v2.1.1-rc.11:
     en:
       - '[feature] Add on-focus on-blur event #1082 @zeusLeeJh'


### PR DESCRIPTION
textarea的counter部分，因为UI上和textarea是一体的，经常有用户误点。

这里做了一个简单处理，当counter被点击的时候，换起textarea的focus事件，使交互效果和用户期待一致
