### PR TITLE
masker support prop:fullscreen

### DIFF
--- a/src/components/masker/index.vue
+++ b/src/components/masker/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="vux-masker-box">
     <slot></slot>
-    <div class="vux-masker" :style="style">
+    <div class="vux-masker" :class="{'vux-masker-fullscreen': fullscreen}" :style="style">
       <slot name="content"></slot>
     </div>
   </div>
@@ -19,6 +19,10 @@ export default {
     opacity: {
       type: Number,
       default: 0.5
+    },
+    fullscreen: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -43,5 +47,9 @@ export default {
   bottom: 0;
   right: 0;
   border-radius: inherit;
+}
+.vux-masker-fullscreen {
+  position: fixed;
+  z-index: 10001;
 }
 </style>

--- a/src/components/masker/metas.yml
+++ b/src/components/masker/metas.yml
@@ -10,6 +10,11 @@ props:
     default: 0.5
     en: the opacity of the mask
     zh-CN: 遮罩透明度
+  fullscreen:
+    type: Boolean
+    default: false
+    en: if masker is fullscreen
+    zh-CN: 遮罩是否全屏
 slots:
   default:
     en: content below the mask
@@ -17,3 +22,9 @@ slots:
   content:
     en: content above the mask
     zh-CN: 遮罩上方内容，一般显示标题消息
+changes:
+  next:
+    en:
+      - '[feature] Support prop:fullscreen'
+    zh-CN:
+      - '[feature] 支持通过prop设置是否全屏显示'


### PR DESCRIPTION
有时候，需要一个全屏的遮罩。

所以给masker加了个prop属性fullscreen，当fullscreen设置为true的时候，遮罩全屏显示