### PR TITLE
Demo: Fix scrolling direction bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -142,7 +142,7 @@ router.beforeEach(function (to, from, next) {
   const fromIndex = history.getItem(from.path)
 
   if (toIndex) {
-    if (toIndex > fromIndex || !fromIndex || (toIndex === '0' && fromIndex === '0')) {
+    if (!fromIndex || parseInt(toIndex, 10) > parseInt(fromIndex, 10) || (toIndex === '0' && fromIndex === '0')) {
       store.commit('updateDirection', {direction: 'forward'})
     } else {
       store.commit('updateDirection', {direction: 'reverse'})


### PR DESCRIPTION
修复Demo页面滚动方向Bug。
toIndex 和 fromIndex 是string类型的，直接比较会出问题，比如 '2' > '10'。
当Demo访问页面个数较多时，就可能因大小关系错误，导致滚动方向错误。

Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors
