### PR TITLE
Update x-header doc

### DIFF
--- a/src/components/x-header/metas.yml
+++ b/src/components/x-header/metas.yml
@@ -49,8 +49,8 @@ events:
     en: triggers when more icon is clicked
     zh-CN: 点击右侧更多时触发
   on-click-back:
-    en: triggers when left part is clicked
-    zh-CN: 点击左边返回时触发
+    en: triggers when left part is clicked and the prop 'left-options.preventGoBack' is true
+    zh-CN: 当left-options.preventGoBack为true,点击左边返回时触发
   on-click-title:
     en: triggers when title is clicked
     zh-CN: 点击标题时触发


### PR DESCRIPTION
在使用x-header中发现单独使用`on-click-back`方法触发不了,看代码才发现前提条件是`left-options.preventGoBack`为`true`
