### PR TITLE
irrelevant props can be removed?

### DIFF
--- a/src/components/group/index.vue
+++ b/src/components/group/index.vue
@@ -13,9 +13,6 @@ export default {
   props: {
     title: String,
     titleColor: String,
-    labelWidth: String,
-    labelAlign: String,
-    labelMarginRight: String,
     gutter: String
   }
 }


### PR DESCRIPTION
labelWidth / labelAlign / labelMarginRight don't match with group title / group cells wrapper and never used in group component, so just remove them by no influence?