### PR TITLE
swipeout:Fix unable to trigger click event when disabled on android

### DIFF
--- a/src/components/swipeout/metas.yml
+++ b/src/components/swipeout/metas.yml
@@ -88,5 +88,7 @@ changes:
   next:
     en:
       - '[fix] Fix cannot scroll when disabled'
+      - '[fix] Fix unable to trigger click event when disabled on android'
     zh-CN:
       - '[fix] 修复disabled时不能上下滚动问题'
+      - '[fix] 修复disabled时，安卓手机上不能触发点击事件的问题'

--- a/src/components/swipeout/swipeout-item.vue
+++ b/src/components/swipeout/swipeout-item.vue
@@ -144,7 +144,6 @@ export default {
     },
     end (ev) {
       if (this.disabled) {
-        ev.preventDefault()
         return
       }
       if (ev.target.nodeName.toLowerCase() === 'button') {


### PR DESCRIPTION
修复disabled时，content部分在安卓手机上不能触发点击事件的问题

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
