### PR TITLE
remove extra "required" prop

### DIFF
--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -181,10 +181,6 @@ export default {
     InlineDesc
   },
   props: {
-    required: {
-      type: Boolean,
-      default: false
-    },
     title: {
       type: String,
       default: ''


### PR DESCRIPTION
Remove `required` prop because it has been minxined at `mixins: [Base]` base.js file Line: 6