### PR TITLE
remove useless style

### DIFF
--- a/src/components/flexbox/flexbox.vue
+++ b/src/components/flexbox/flexbox.vue
@@ -53,9 +53,6 @@ export default {
   min-width: 20px;
   width: 0%;
 }
-.vux-flexbox-item > .vux-flexbox {
-  width: 100%;
-}
 
 .vux-flexbox .vux-flexbox-item:first-child {
   margin-left: 0!important;


### PR DESCRIPTION
remove `.vux-flexbox-item > .vux-flexbox` because:
1. searched global in whole files, 'vux-flexbox' only used in flexbox component, and never exists anywhere else;
2. if want to express `<flexbox><flexbox-item><flexbox>...</flexbox></flexbox-item></flexbox>`, flexbox nested in flexbox-item, and set `width: 100%`, it's no necessary beacause Line: 42 will work. 

please help confirm?