### PR TITLE
delete warning message and disable methods add and sub when value of x-number is  empty string

### DIFF
--- a/src/components/x-number/index.vue
+++ b/src/components/x-number/index.vue
@@ -31,7 +31,14 @@ export default {
       default: 1
     },
     value: {
-      type: Number,
+      validator (value) {
+        if (typeof value === 'number') {
+          return true
+        } else if (typeof value === 'string') {
+          return value === ''
+        }
+        return false
+      },
       default: 0
     },
     name: String,
@@ -63,10 +70,10 @@ export default {
   },
   computed: {
     disabledMin () {
-      return typeof this.min === 'undefined' ? false : this.currentValue <= this.min
+      return typeof this.min === 'undefined' ? false : (this.currentValue === '' ? true : this.currentValue <= this.min)
     },
     disabledMax () {
-      return typeof this.max === 'undefined' ? false : this.currentValue >= this.max
+      return typeof this.max === 'undefined' ? false : (this.currentValue === '' ? true : this.currentValue >= this.max)
     }
   },
   watch: {
@@ -101,11 +108,7 @@ export default {
     },
     blur () {
       if (this.currentValue === '') {
-        if (this.min) {
-          this.currentValue = this.min
-        } else {
-          this.currentValue = 0
-        }
+        this.currentValue = 0
       }
     }
   }

--- a/src/components/x-number/metas.yml
+++ b/src/components/x-number/metas.yml
@@ -69,6 +69,11 @@ props:
     en: align setting of the selecting area
     zh-CN: '按钮部分位置，默认在右边(right)，可选值为`left`和`right`'
 changes:
+  next:
+    en:
+      - '[fix] delete prop-check-warning message, and disable `add` and `sub` method when `value` is empty string'
+    zh-CN:
+      - '[fix] `value`为空字符串时，去掉 prop 类型检测 warning 信息，并禁用 `add` 和 `sub` 方法'
   v2.2.1-rc.8:
     en:
       - '[fix] fix cannot edit first number character when fillable'


### PR DESCRIPTION
当x-number的value是空字符串的时候，会出现prop值校验warning信息，虽然也不影响使用，但仍然处理一下； 

value为空字符串的时候，加减按钮也进行禁用处理。

