### PR TITLE
enhance inline-calendar when replace text is empty string

### DIFF
--- a/src/components/inline-calendar/index.vue
+++ b/src/components/inline-calendar/index.vue
@@ -37,7 +37,7 @@
           :class="buildClass(k2, child, formatDate(year, month, child) === currentValue && !child.isLastMonth && !child.isNextMonth)"
           @click="select(k1,k2,child)">
             <span
-            v-show="(!child.isLastMonth && !child.isNextMonth ) || (child.isLastMonth && showLastMonth) || (child.isNextMonth && showNextMonth)">{{replaceText(child.day, formatDate(year, month, child))}}</span>
+            v-show="showChild(year, month, child)">{{replaceText(child.day, formatDate(year, month, child))}}</span>
             <div v-html="renderFunction(k1, k2, child)"></div>
           </td>
         </tr>
@@ -121,7 +121,12 @@ export default {
   },
   methods: {
     replaceText (day, formatDay) {
-      return this._replaceTextList[formatDay] || day
+      let text = this._replaceTextList[formatDay]
+      if (!text && typeof(text) === 'undefined') {
+        return day
+      } else {
+        return text
+      }
     },
     convertDate (date) {
       return date === 'TODAY' ? this.today : date
@@ -183,6 +188,13 @@ export default {
         this.currentValue = [this.year, zero(this.month + 1), zero(this.days[k1][k2].day)].join('-')
       } else {
         this.currentValue = [data.year, zero(data.month + 1), zero(data.day)].join('-')
+      }
+    },
+    showChild (year, month, child) {
+      if (this.replaceText(child.day, this.formatDate(year, month, child))) {
+        return (!child.isLastMonth && !child.isNextMonth ) || (child.isLastMonth && this.showLastMonth) || (child.isNextMonth && this.showNextMonth)
+      } else {
+        return false
       }
     }
   }

--- a/src/components/inline-calendar/metas.yml
+++ b/src/components/inline-calendar/metas.yml
@@ -88,6 +88,11 @@ props:
     en: if disable future days
     zh-CN: 禁止选择未来的日期，该选项可以end-date同时使用
 changes:
+  next:
+    en:
+      - "[enhance] when replace text of date is empty string, span of date will not show"
+    zh-CN:
+      - '[enhance] 当日期的替代文字为空字符串时，包含日期的 `span` 元素将不显示'
   v2.2.1-rc.2:
     en:
       - "[enhance] Now next month's day can be clicked and will automatically switch to next month's view #1192"


### PR DESCRIPTION
当inline-calendar的替代文字为空的时候，仍然将默认文字替换为空字符串，并且默认的span元素不显示