### PR TITLE
fix x-input validate

### DIFF
--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -154,10 +154,10 @@ const validators = {
     },
     msg: '中文姓名'
   },
-	'url': {
-		fn: isURL,
-		msg: '网址'
-	}
+  'url': {
+    fn: isURL,
+    msg: '网址'
+  }
 }
 export default {
   name: 'x-input',
@@ -322,18 +322,18 @@ export default {
         return
       }
 
-			if (this.required) {
-				this.valid = !!this.currentValue
+      if (this.required) {
+        this.valid = !!this.currentValue
 
-				if (!this.valid) {
-					this.errors.required = this.title + '是必填项噢'
-					this.forceShowError = true
-					this.getError()
-	        return
-				} else {
-					delete this.errors.required
-				}
-			}
+        if (!this.valid) {
+          this.errors.required = this.title + '是必填项噢'
+          this.forceShowError = true
+          this.getError()
+          return
+        } else {
+          delete this.errors.required
+        }
+      }
 
       if (typeof this.isType === 'string') {
         const validator = validators[this.isType]
@@ -378,7 +378,7 @@ export default {
           this.errors.max = `最多可以输入${this.max}个字符哦`
           this.valid = false
           this.forceShowError = true
-					this.getError()
+          this.getError()
           return
         } else {
           this.forceShowError = false
@@ -386,7 +386,7 @@ export default {
         }
       }
 
-			this.getError()
+      this.getError()
       this.valid = true
     },
     validateEqual () {

--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -133,6 +133,7 @@ import InlineDesc from '../inline-desc'
 
 import isEmail from 'validator/lib/isEmail'
 import isMobilePhone from 'validator/lib/isMobilePhone'
+import isURL from 'validator/lib/isURL'
 
 import Debounce from '../../tools/debounce'
 
@@ -152,7 +153,11 @@ const validators = {
       return str.length >= 2 && str.length <= 6
     },
     msg: '中文姓名'
-  }
+  },
+	'url': {
+		fn: isURL,
+		msg: '网址'
+	}
 }
 export default {
   name: 'x-input',
@@ -317,19 +322,26 @@ export default {
         return
       }
 
-      if (!this.currentValue && this.required) {
-        this.valid = false
-        this.errors.required = '必填哦'
-        this.getError()
-        return
-      }
+			if (this.required) {
+				this.valid = !!this.currentValue
+
+				if (!this.valid) {
+					this.errors.required = this.title + '是必填项噢'
+					this.forceShowError = true
+					this.getError()
+	        return
+				} else {
+					delete this.errors.required
+				}
+			}
 
       if (typeof this.isType === 'string') {
         const validator = validators[this.isType]
         if (validator) {
           this.valid = validator[ 'fn' ](this.currentValue)
           if (!this.valid) {
-            this.errors.format = validator[ 'msg' ] + '格式不对哦~'
+            this.errors.format = validator[ 'msg' ] + '格式不正确哦~'
+            this.getError()
             return
           } else {
             delete this.errors.format
@@ -342,10 +354,8 @@ export default {
         this.valid = validStatus.valid
         if (!this.valid) {
           this.errors.format = validStatus.msg
-          this.forceShowError = true
-          if (!this.firstError) {
-            this.getError()
-          }
+          //this.forceShowError = true
+          this.getError()
           return
         } else {
           delete this.errors.format
@@ -356,9 +366,7 @@ export default {
         if (this.currentValue.length < this.min) {
           this.errors.min = `最少应该输入${this.min}个字符哦`
           this.valid = false
-          if (!this.firstError) {
-            this.getError()
-          }
+          this.getError()
           return
         } else {
           delete this.errors.min
@@ -370,6 +378,7 @@ export default {
           this.errors.max = `最多可以输入${this.max}个字符哦`
           this.valid = false
           this.forceShowError = true
+					this.getError()
           return
         } else {
           this.forceShowError = false
@@ -377,6 +386,7 @@ export default {
         }
       }
 
+			this.getError()
       this.valid = true
     },
     validateEqual () {


### PR DESCRIPTION
修复若干个有关验证的问题

Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [x] No `eslint` errors

PR细节：

1. 原版本有 required 属性的 ref 组件直接调用 validate 方法，虽然 vaild 属性改为 false，但在 UI 层并没有标红和相关图标，通过加入 forceShowError  解决问题。且修正代码内 required 属性的验证与其它验证的写法成一致。
2. firstError 的出现逻辑修正。原版本会出现旧 error 的 msg 一直存放在 firstError。现在改成了每一次验证都更新 x-input 的 firstError，方便前端直接使用 firstError 进行提示。（在我阅读源码的感觉来看，firstError 应该是用于处理当一个 input 出现多个 error 时，直接可以取第一个 error。但是代码实际情况是，当其中一个验证 error 发生时，就会标 valid false 并退出验证。firstError 还保留着最初的 error 应该是没意义的吧？除了它有更重要的用法）
3. 内置验证在验证后忘记添加 getError，导致 firstError 内获取不到内置验证的验证信息。（除非 firstError 真的不是这样用的。。。我个人是直接取 firstError 来获取这一次的验证信息的）
4. 去除自定义验证的 forceShowError  ，自定义验证应该和内置验证器使用同一种交互逻辑，也就是首次输入 blur 后才触发验证。
5. 加入内置 URL 验证，这个属于我个人需求。但鉴于原生 form 表单也内置的 URL 验证，所以个人觉得也是很有必要的。
