### PR TITLE
emit input before on-change

### DIFF
--- a/src/components/checklist/index.vue
+++ b/src/components/checklist/index.vue
@@ -137,8 +137,8 @@ export default {
     },
     currentValue (newVal) {
       const val = pure(newVal)
-      this.$emit('on-change', val)
       this.$emit('input', val)
+      this.$emit('on-change', val)
 
       let err = {}
       if (this._min) {

--- a/src/components/checklist/metas.yml
+++ b/src/components/checklist/metas.yml
@@ -87,3 +87,8 @@ changes:
       - '[feature] 添加插槽 footer、after-title'
       - '[change] 如果已经达到max上限，没有选中的选项将不能选择，因此不再和之前版本一样会出现最多可选max个的error信息'
       - '[change] 默认 required 值为false, 与html规范一致'
+  next:
+    en:
+      - '[fix] emit event `input` before `on-change`'
+    zh-CN:
+      - '[fix] 在 `on-change` 事件之前 emit `input` 事件'


### PR DESCRIPTION
目前是先 emit `on-change`，然后 emit `input`，这导致父组件接收到on-change事件后，父组件中的数据还没有更新，从而无法进行下一步操作。

暂时我是通过把 `on-change`的实际操作放到 `$nextTick` 内完成来规避这个问题，但是感觉不是很合理。
