### PR TITLE
checklist: prop options add attribute inlineDesc

### DIFF
--- a/src/components/checklist/index.vue
+++ b/src/components/checklist/index.vue
@@ -10,6 +10,7 @@
         </div>
         <div class="weui-cell__bd">
           <p v-html="getValue(one)"></p>
+          <inline-desc v-if="getInlineDesc(one)">{{getInlineDesc(one)}}</inline-desc>
         </div>
       </label>
     </div>
@@ -21,14 +22,16 @@
 import Base from '../../libs/base'
 import Tip from '../tip'
 import Icon from '../icon'
-import { getValue, getKey } from './object-filter'
+import InlineDesc from '../inline-desc'
+import { getValue, getKey, getInlineDesc } from './object-filter'
 import shuffle from 'array-shuffle'
 
 export default {
   name: 'checklist',
   components: {
     Tip,
-    Icon
+    Icon,
+    InlineDesc
   },
   filters: {
     getValue,
@@ -82,6 +85,7 @@ export default {
   methods: {
     getValue,
     getKey,
+    getInlineDesc,
     ifDisable (key) {
       if (!this.checkDisabled) {
         return false

--- a/src/components/checklist/metas.yml
+++ b/src/components/checklist/metas.yml
@@ -24,7 +24,7 @@ props:
     type: Array
     default: []
     en: option list
-    zh-CN: 选项列表，可以为`[{key:'name',value:'value'}]`的形式
+    zh-CN: 选项列表，可以为`[{key:'name',value:'value',inlineDesc:'inlineDesc'}]`的形式
   max:
     type: Number
     default: ''
@@ -90,5 +90,7 @@ changes:
   next:
     en:
       - '[fix] emit event `input` before `on-change`'
+      - '[feature] add attribute `inlineDesc` to `options`'
     zh-CN:
       - '[fix] 在 `on-change` 事件之前 emit `input` 事件'
+      - '[feature] `options` 中增加 `inlineDesc` 属性'

--- a/src/components/checklist/object-filter.js
+++ b/src/components/checklist/object-filter.js
@@ -5,3 +5,7 @@ export const getValue = function (item) {
 export const getKey = function (item) {
   return typeof item === 'object' ? item.key : item
 }
+
+export const getInlineDesc = function (item) {
+  return typeof item === 'object' ? item.inlineDesc : ''
+}

--- a/src/demos/Checklist.vue
+++ b/src/demos/Checklist.vue
@@ -20,6 +20,8 @@
 
     <checklist :title="$t('Option Array with key and value(key must be string)')" :options="objectList" v-model="objectListValue" @on-change="change"></checklist>
 
+    <checklist :title="$t('Option is Object with InlineDesc')" :options="inlineDescList" v-model="inlineDescListValue" @on-change="change"></checklist>
+
     <checklist :title="$t('Async list')" :max="3" :options="asyncList" v-model="asyncListValue" @on-change="change"></checklist>
 
     <divider>Reference</divider>
@@ -40,6 +42,8 @@ set random order:
   zh-CN: 打乱选项顺序
 'Option Array with key and value(key must be string)':
   zh-CN: 使用Object类型的选项列表，key必须为字符串
+Option is Object with InlineDesc:
+  zh-CN: 包含inlineDesc属性的Object类型选项列表
 Async list:
   zh-CN: 异步选项列表
 </i18n>
@@ -96,6 +100,12 @@ export default {
       checklist005Value: [],
       objectList: [{key: '1', value: '001 value'}, {key: '2', value: '002 value'}, {key: '3', value: '003 value'}],
       objectListValue: ['1', '2'],
+      inlineDescList: [
+        {key: '1', value: 'tiger is good', inlineDesc: 'Tiger is the king of mountain'},
+        {key: '2', value: 'lion is better', inlineDesc: 'Lion is the king of woods'},
+        {key: '3', value: 'camel is best, no inline-desc'}
+      ],
+      inlineDescListValue: [1],
       asyncList: [],
       asyncListValue: []
     }


### PR DESCRIPTION
`checklist` 组件的 `options` 中增加一个 可以为空的`inlineDesc` 属性，这样支持更丰富的交互界面。

`demo`  和  `文档` 都已经同步更新。