### PR TITLE
add function setter to computed attribute dirty of base

### DIFF
--- a/src/libs/base.js
+++ b/src/libs/base.js
@@ -12,8 +12,13 @@ export default {
     this.handleChangeEvent = false
   },
   computed: {
-    dirty () {
-      return !this.prisine
+    dirty: {
+      get: function () {
+        return !this.pristine
+      },
+      set: function (newValue) {
+        this.pristine = !newValue
+      }
     },
     invalid () {
       return !this.valid
@@ -26,8 +31,8 @@ export default {
   },
   watch: {
     value (newVal) {
-      if (this.prisine === true) {
-        this.prisine = false
+      if (this.pristine === true) {
+        this.pristine = false
       }
       if (!this.handleChangeEvent) {
         this.$emit('on-change', newVal)
@@ -38,7 +43,7 @@ export default {
   data () {
     return {
       errors: {},
-      prisine: true,
+      pristine: true,
       touched: false
     }
   }


### PR DESCRIPTION
base.js中的计算属性dirty，在x-input的reset中有set操作，会报错。
在base.js中增加了计算属性中的setter函数
同时顺便修改了我觉得是写错的单词