### PR TITLE
修改scroller组件，调用xscroll的destroy方法，从beforeDestroy换到destory

### DIFF
--- a/src/components/scroller/index.vue
+++ b/src/components/scroller/index.vue
@@ -307,7 +307,7 @@ export default {
     })
     this.getStyles()
   },
-  beforeDestroy () {
+  destoryed () {
     if (this.pullup) {
       this._xscroll.unplug(this.pullup)
       this.pullup.pluginDestructor()

--- a/src/components/scroller/metas.yml
+++ b/src/components/scroller/metas.yml
@@ -226,6 +226,11 @@ methods:
     en: set pulldown done after new data is fetched
     zh-CN: 设置下拉刷新操作完成，在数据加载后执行
 changes:
+  next:
+    en:
+      - '[change] call the xscroll destroy method, change beforeDestroy to destoryed'
+    zh-CN:
+      - '[change] 调用xscroll的destroy方法，从beforeDestroy换到destoryed'
   v2.2.1-rc.8:
     en:
       - '[change] set prop:prevent-default to false by default'


### PR DESCRIPTION
切换路由时，有动画过度时，如果是在beforeDestory调用xscroll的destory方法的话，在开始过度时滚动条会回到顶部，因为xscroll被destory了，如果在destory时再执行xscroll的destory方法就没有该问题。

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors
