### PR TITLE
XInput: update "firstError" check

### DIFF
--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -385,9 +385,7 @@ export default {
         if (!this.valid) {
           this.errors.format = validStatus.msg
           this.forceShowError = true
-          if (!this.firstError) {
-            this.getError()
-          }
+          this.getError()
           return
         } else {
           delete this.errors.format


### PR DESCRIPTION
Remove "firstError" check when "isType equals function". 
As a result of that, you can get the latest error message show in the "Toast".
Why? 
Sometimes we want to tells the user much more error details about there typing, more than "the first error". 
For Instance: "Identity No" check, "Amount” check.

Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors
