### PR TITLE
修复Search组件onBlur事件不触发

### DIFF
--- a/src/components/search/index.vue
+++ b/src/components/search/index.vue
@@ -122,7 +122,6 @@ export default {
     },
     setBlur () {
       this.$refs.input.blur()
-      this.$emit('on-blur')
     },
     onFocus () {
       this.isFocus = true
@@ -131,6 +130,7 @@ export default {
     },
     onBlur () {
       this.isFocus = false
+      this.$emit('on-blur')
     }
   },
   data () {


### PR DESCRIPTION
目前onBlur只在主动setBlur才会触发，修改了$emit的调用位置

Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors
