### PR TITLE
修复LoadMore 组件，当 tip 为空，且 show-loading 为 false 时背景颜色不对的问题

### DIFF
--- a/src/components/load-more/index.vue
+++ b/src/components/load-more/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="weui-loadmore" :class="{'weui-loadmore_line':!showLoading, 'weui-loadmore_dot': !showLoading && !tip}">
     <i class="weui-loading" v-if="showLoading"></i>
-    <span class="weui-loadmore__tips" :style="getStyle()" v-show="tip || !showLoading">{{tip}}</span>
+    <span class="weui-loadmore__tips" :style="styles" v-show="tip || !showLoading">{{tip}}</span>
   </div>
 </template>
 
@@ -16,12 +16,10 @@ export default {
     tip: String,
     backgroundColor: String
   },
-  methods: {
-    getStyle () {
-      if (!this.showLoading && this.tip) {
-        return {
-          'background-color': this.backgroundColor
-        }
+  computed: {
+    styles () {
+      return {
+        'background-color': this.backgroundColor
       }
     }
   }

--- a/src/components/load-more/metas.yml
+++ b/src/components/load-more/metas.yml
@@ -11,10 +11,16 @@ props:
   background-color:
     type: String
     default: '#ffffff'
-    en: background color. Recommend to use @load-more-tip-background-color for global 
+    en: background color. Recommend to use @load-more-tip-background-color for global
     zh-CN: 背景颜色，需要配置以让文字与背景完全融合。推荐通过设置 less 变量 @load-more-tip-background-color 全局修改
 changes:
+  next:
+    en:
   v2.6.0:
+    en:
+      - '[fix] fix `tip` is empty and `show-loading` is `false`, the background color is not correct'
+    zh-CN:
+      - '[fix] 修复 `tip` 为空，且 `show-loading` 为 `false` 时背景颜色不对的问题 '
     en:
       - '[feature] support less variable @load-more-tip-background-color'
     zh-CN:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8528523/34318809-8e61c39c-e80b-11e7-806a-5ed3ec72ad18.png)


* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors
