### PR TITLE
fix 'popup-radio' component the 'border-intent' property

### DIFF
--- a/src/components/popup-radio/index.vue
+++ b/src/components/popup-radio/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <cell @click.native="show" :title="title" :value="currentValue" :is-link="!readonly" :value-align="valueAlign">
+  <cell @click.native="show" :title="title" :value="currentValue" :is-link="!readonly" :value-align="valueAlign" :border-intent="borderIntent">
     <span class="vux-cell-placeholder" v-if="!displayValue && placeholder">{{ placeholder }}</span>
     <span class="vux-cell-value" v-if="displayValue">{{ displayValue }}</span>
     <span slot="icon">

--- a/src/components/popup-radio/metas.yml
+++ b/src/components/popup-radio/metas.yml
@@ -33,11 +33,11 @@ events:
     en: fires when popup hides
     zh-CN: 弹窗关闭时触发
 changes:
-  v2.7.8
+  next
     en:
-      - '[fix] fix 'popup-radio' component does not support the 'border-intent' property of the cell component.
+      - '[fix] fix popup-radio component does not support the border-intent property of the cell component.'
     zh-CN:
-      - '[fix] 修复'popup-radio'组件不支持cell组件中'border-intent'的属性。
+      - '[fix] 修复 popup-radio 组件不支持cell组件中 border-intent 的属性。'
   v2.7.0:
     en:
       - '[fix] fix vue@2.5.0 scope issue #2076'

--- a/src/components/popup-radio/metas.yml
+++ b/src/components/popup-radio/metas.yml
@@ -33,6 +33,11 @@ events:
     en: fires when popup hides
     zh-CN: 弹窗关闭时触发
 changes:
+  v2.7.8
+    en:
+      - '[fix] fix 'popup-radio' component does not support the 'border-intent' property of the cell component.
+    zh-CN:
+      - '[fix] 修复'popup-radio'组件不支持cell组件中'border-intent'的属性。
   v2.7.0:
     en:
       - '[fix] fix vue@2.5.0 scope issue #2076'


### PR DESCRIPTION
fix 'popup-radio' component does not support the  'border-intent' property of the cell component.
修复'popup-radio'组件不支持cell组件中的'border-intent'属性。

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
