### PR TITLE
fix:Picker chain mode get value is error as maybe.

### DIFF
--- a/src/components/picker/index.vue
+++ b/src/components/picker/index.vue
@@ -136,8 +136,13 @@ export default {
           _this.renderChain(i + 1)
         }
       })
-      this.$set(this.currentValue, i, list[0].value)
-      this.renderChain(i + 1)
+      // list is Array(empty) as maybe
+      if (list.length) {
+        this.$set(this.currentValue, i, list[0].value)
+        this.renderChain(i + 1)
+      } else {
+        this.$set(this.currentValue, i, null)
+      }
     },
     getValue () {
       let data = []


### PR DESCRIPTION
#### 修复Picker组件在多级联动模式下，没有下级数据时报错，getValue方法无法取到正确联动数据。

###### 问题重现：Xaddress组件绑定多级联动数据，其中某个父级没有子数据。
