### PR TITLE
fix:Picker chain mode get value is wrong as maybe.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ config/*.js
 src/tools/*/*.js
 src/components/video/zy.media.js
 src/plugins/wechat/1.3.0.js
+src/plugins/wechat/origin.1.3.0.js

--- a/src/components/picker/index.vue
+++ b/src/components/picker/index.vue
@@ -136,8 +136,13 @@ export default {
           _this.renderChain(i + 1)
         }
       })
-      this.$set(this.currentValue, i, list[0].value)
-      this.renderChain(i + 1)
+      // list is Array(empty) as maybe
+      if (list.length) {
+        this.$set(this.currentValue, i, list[0].value)
+        this.renderChain(i + 1)
+      } else {
+        this.$set(this.currentValue, i, null)
+      }
     },
     getValue () {
       let data = []

--- a/src/components/picker/metas.yml
+++ b/src/components/picker/metas.yml
@@ -132,6 +132,11 @@ methods:
     en: get labels of current value
     zh-CN: 根据 value 获取字面值
 changes:
+  next:
+    en:
+      - '[fix] Fix chain mode get value is wrong when the children is empty data.'
+    zh-CN:
+      - '[fix] 修复多级联动模式下，子代没有数据时，取值不正确。'
   v2.7.3:
     en:
       - '[enhance] add development tip for chained-mode picker without specifying prop:columns'


### PR DESCRIPTION
#### 修复Picker组件在多级联动模式下，没有下级数据时报错，getValue方法无法取到正确联动数据。

###### 重现方式：Xaddress组件绑定多级联动数据，其中某个父级没有子数据，滚动到该父级元素时，控制台报错，子级视图更新，点击确认按钮，value显示错误。

###### tips: 新引入的微信插件origin.1.3.0.js不符合eslint规范，导致pull request直接检测失败。这里已经将其忽略。