### PR TITLE
fix: 修复 switch transfrom 所引起的层级改变，导致弹窗不显示问题

### DIFF
--- a/src/components/x-dialog/index.vue
+++ b/src/components/x-dialog/index.vue
@@ -3,10 +3,10 @@
     class="vux-x-dialog"
     :class="{'vux-x-dialog-absolute': layout === 'VIEW_BOX'}">
     <transition :name="maskTransition">
-      <div class="weui-mask" @click="hide" v-show="show" :style="maskStyle"></div>
+      <div class="weui-mask" @click="hide" v-show="dialogShow" :style="maskStyle"></div>
     </transition>
     <transition :name="dialogTransition">
-      <div :class="dialogClass" v-show="show" :style="dialogStyle">
+      <div :class="dialogClass" v-show="dialogShow" :style="dialogStyle">
         <slot></slot>
       </div>
     </transition>
@@ -65,6 +65,7 @@ export default {
     }
   },
   mounted () {
+    this.dialogShow = this.show
     if (typeof window !== 'undefined') {
       if (window.VUX_CONFIG && window.VUX_CONFIG.$layout === 'VIEW_BOX') {
         this.layout = 'VIEW_BOX'
@@ -73,13 +74,16 @@ export default {
   },
   watch: {
     show (val) {
-      this.$emit('update:show', val)
-      this.$emit(val ? 'on-show' : 'on-hide')
-      if (val) {
-        this.addModalClassName()
-      } else {
-        this.removeModalClassName()
-      }
+      setTimeout(() => {
+        this.dialogShow = val
+        this.$emit('update:show', val)
+        this.$emit(val ? 'on-show' : 'on-hide')
+        if (val) {
+          this.addModalClassName()
+        } else {
+          this.removeModalClassName()
+        }
+      }, 200)
     }
   },
   methods: {
@@ -101,7 +105,8 @@ export default {
   },
   data () {
     return {
-      layout: ''
+      layout: '',
+      dialogShow: ''
     }
   }
 }


### PR DESCRIPTION
因为在用 switch 打开 dialog 时， 在 ios 上会因为 transfrom 导致 上下堆叠层级暂时失效，所以等 switch 
的 transfrom 完成后 再弹出dialog 经自测可以解决问题。 这里就是用的 延迟 150 ms 显示。
