### PR TITLE
增加XCircle的外圈渐变颜色的配置

### DIFF
--- a/src/components/x-circle/index.vue
+++ b/src/components/x-circle/index.vue
@@ -1,10 +1,25 @@
 <template>
   <div class="vux-circle">
     <svg viewBox="0 0 100 100">
-      <path :d="pathString" :stroke="trailColor" :stroke-width="trailWidth" :fill-opacity="0"/>
-      <path :d="pathString" :stroke-linecap="strokeLinecap" :stroke="strokeColor" :stroke-width="strokeWidth" fill-opacity="0" :style="pathStyle"/>
+      <defs v-if="isGradient">
+        <linearGradient id="orange_red" x1="10%" y1="45%" x2="50%" y2="0%">
+          <stop offset="0%" :style="{'stop-color': strokeColor[0], 'stop-opacity': 1}"/>
+          <stop offset="100%" :style="{'stop-color': strokeColor[1], 'stop-opacity': 1}"/>
+        </linearGradient>
+      </defs>
+      <path :d="pathString"
+            :stroke="trailColor"
+            :stroke-width="trailWidth"
+            :fill-opacity="0"/>
+      <path :d="pathString"
+            :stroke-linecap="strokeLinecap"
+            :stroke="isGradient ? 'url(#orange_red)' : strokeColor"
+            :stroke-width="strokeWidth"
+            fill-opacity="0" :style="pathStyle"/>
     </svg>
-    <div class="vux-circle-content"><slot></slot></div>
+    <div class="vux-circle-content">
+      <slot></slot>
+    </div>
   </div>
 </template>
 
@@ -22,7 +37,7 @@ export default {
       default: 1
     },
     strokeColor: {
-      type: String,
+      type: [Array, String],
       default: '#3FC7FA'
     },
     trailWidth: {
@@ -60,6 +75,9 @@ export default {
         'stroke-dashoffset': `${((100 - this.percent) / 100 * this.len)}px`,
         'transition': 'stroke-dashoffset 0.6s ease 0s, stroke 0.6s ease'
       }
+    },
+    isGradient () {
+      return typeof this.strokeColor !== 'string'
     }
   }
 }

--- a/src/components/x-circle/index.vue
+++ b/src/components/x-circle/index.vue
@@ -2,20 +2,20 @@
   <div class="vux-circle">
     <svg viewBox="0 0 100 100">
       <defs v-if="isGradient">
-        <linearGradient id="orange_red" x1="10%" y1="45%" x2="50%" y2="0%">
+        <linearGradient x1="10%" y1="45%" x2="50%" y2="0%">
           <stop offset="0%" :style="{'stop-color': strokeColor[0], 'stop-opacity': 1}"/>
           <stop offset="100%" :style="{'stop-color': strokeColor[1], 'stop-opacity': 1}"/>
         </linearGradient>
       </defs>
       <path :d="pathString"
-            :stroke="trailColor"
-            :stroke-width="trailWidth"
-            :fill-opacity="0"/>
+        :stroke="trailColor"
+        :stroke-width="trailWidth"
+        :fill-opacity="0"/>
       <path :d="pathString"
-            :stroke-linecap="strokeLinecap"
-            :stroke="isGradient ? 'url(#orange_red)' : strokeColor"
-            :stroke-width="strokeWidth"
-            fill-opacity="0" :style="pathStyle"/>
+        :stroke-linecap="strokeLinecap"
+        :stroke="isGradient ? 'url(#orange_red)' : strokeColor"
+        :stroke-width="strokeWidth"
+        fill-opacity="0" :style="pathStyle"/>
     </svg>
     <div class="vux-circle-content">
       <slot></slot>


### PR DESCRIPTION
为满足该组件的渐变色，在vux版本为`@2.8.1`的XCircle组件的基础上添加了一些自己的代码。
>核心：

通过判断strokeColor是数组还是字符串来决定是否渲染渐变色

#### 效果如下图：

![image](https://user-images.githubusercontent.com/19463934/38186430-96396214-3685-11e8-8013-8322a932b16a.png)

