### PR TITLE
fix: 修复demo页在移动端横屏切换至竖屏时高度显示的问题

### DIFF
--- a/src/demos/DemoList.vue
+++ b/src/demos/DemoList.vue
@@ -68,14 +68,16 @@ export default {
   },
   data () {
     return {
-      height: window.innerHeight - 46 - 53,
       components: this.split(components)
     }
   },
   computed: {
     ...mapState({
       demoTop: state => state.vux.demoScrollTop
-    })
+    }),
+    height(){
+      return window.innerHeight - 46 - 53
+    }
   }
 }
 </script>


### PR DESCRIPTION
在pad端看demo示例时，由横屏切换至竖屏时，高度展示仍然是横屏的高度
