### PR TITLE
Fix swiper component auto height problem.

### DIFF
--- a/src/components/swiper/swiper.vue
+++ b/src/components/swiper/swiper.vue
@@ -114,13 +114,13 @@ export default {
     },
     getHeight () {
       const hasHeight = parseInt(this.height, 10)
-      if (hasHeight) return this.height
-      if (!hasHeight) {
-        if (this.aspectRatio) {
-          return this.$el.offsetWidth * this.aspectRatio + 'px'
-        }
-        return '180px'
+      if (hasHeight) {
+        return this.height
       }
+      if (this.aspectRatio) {
+        return this.$el.offsetWidth * this.aspectRatio + 'px'
+      }
+      return 'auto'
     }
   },
   props: {
@@ -163,7 +163,7 @@ export default {
     },
     height: {
       type: String,
-      default: 'auto'
+      default: '180px'
     },
     aspectRatio: Number,
     minMovingDistance: {


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [ x ] `Rebase` before creating a PR to keep commit history clear.
* [ x ] `Only One commit`
* [ x ] No `eslint` errors

I cannot figure out why height 'auto' will convert to '180px', but for compatibility reason I've modified the default value of 'height' from 'auto' to '180px' in order to make sure this commit will not affect those users who have already using this component with prop 'height' not set.