### PR TITLE
日历组件初始化选定添加[（上/下）个（月/月初/月末）]

### DIFF
--- a/src/components/calendar/index.vue
+++ b/src/components/calendar/index.vue
@@ -210,59 +210,59 @@ export default {
       if (!this.shouldConfirm) {
         this.show = false
       }
-    }
-  },
-  getNextMonth(date) {  
-    var arr = date.split('-');  
-    var year = arr[0]; //获取当前日期的年份  
-    var month = arr[1]; //获取当前日期的月份  
-    var day = arr[2]; //获取当前日期的日  
-    var days = new Date(year, month, 0);  
-    days = days.getDate(); //获取当前日期中的月的天数  
-    var year2 = year;  
+    },
+    getNextMonth(date) {  
+    var arr = date.split('-') 
+    var year = arr[0] //获取当前日期的年份  
+    var month = arr[1] //获取当前日期的月份  
+    var day = arr[2] //获取当前日期的日  
+    var days = new Date(year, month, 0)
+    days = days.getDate() //获取当前日期中的月的天数  
+    var year2 = year
     var month2 = parseInt(month) + 1;  
     if (month2 == 13) {  
     year2 = parseInt(year2) + 1;  
       month2 = 1;  
     }  
-      var day2 = day;  
-      var days2 = new Date(year2, month2, 0);  
-      days2 = days2.getDate();  
+      var day2 = day 
+      var days2 = new Date(year2, month2, 0) 
+      days2 = days2.getDate()
       if (day2 > days2) {  
-        day2 = days2;  
+        day2 = days2 
       }  
         if (month2 < 10) {  
-          month2 = '0' + month2;  
+          month2 = '0' + month2
         }  
           
-          var t2 = year2 + '-' + month2 + '-' + day2;  
-          return t2;  
+          var t2 = year2 + '-' + month2 + '-' + day2
+          return t2  
       }  
-  },
-  getPreMonth(date) {  
-    var arr = date.split('-');  
-    var year = arr[0]; //获取当前日期的年份  
-    var month = arr[1]; //获取当前日期的月份  
-    var day = arr[2]; //获取当前日期的日  
-    var days = new Date(year, month, 0);  
-    days = days.getDate(); //获取当前日期中月的天数  
-    var year2 = year;  
-    var month2 = parseInt(month) - 1;  
+    },
+    getPreMonth(date) {  
+    var arr = date.split('-') 
+    var year = arr[0] //获取当前日期的年份  
+    var month = arr[1] //获取当前日期的月份  
+    var day = arr[2] //获取当前日期的日  
+    var days = new Date(year, month, 0)  
+    days = days.getDate() //获取当前日期中月的天数  
+    var year2 = year 
+    var month2 = parseInt(month) - 1
     if (month2 == 0) {  
-      year2 = parseInt(year2) - 1;  
-      month2 = 12;  
+      year2 = parseInt(year2) - 1 
+      month2 = 12
     }  
-       var day2 = day;  
-       var days2 = new Date(year2, month2, 0);  
-       days2 = days2.getDate();  
+       var day2 = day  
+       var days2 = new Date(year2, month2, 0)  
+       days2 = days2.getDate()  
        if (day2 > days2) {  
-         day2 = days2;  
+         day2 = days2 
        }  
        if (month2 < 10) {  
-         month2 = '0' + month2;  
+         month2 = '0' + month2
        }  
-         var t2 = year2 + '-' + month2 + '-' + day2;  
-         return t2;  
+         var t2 = year2 + '-' + month2 + '-' + day2  
+         return t2 
+    }
   },
   watch: {
     value (newVal, oldVal) {

--- a/src/components/calendar/index.vue
+++ b/src/components/calendar/index.vue
@@ -156,7 +156,7 @@ export default {
       this.$emit('input', this.currentValue)
     } else if (this.value === 'LASTMONTH') {
       var date = new Date();
-      this.currentValue = this.getPreMonth(format(date),'YYYY-MM-DD'))
+      this.currentValue = this.getPreMonth(format(date,'YYYY-MM-DD'))
       this.$emit('input', this.currentValue)
     } else if (this.value === 'LASTMONTH_FIRST') {
       var date = new Date();
@@ -225,19 +225,17 @@ export default {
     year2 = parseInt(year2) + 1;  
       month2 = 1;  
     }  
-      var day2 = day;  
-      var days2 = new Date(year2, month2, 0);  
-      days2 = days2.getDate();  
-      if (day2 > days2) {  
-        day2 = days2;  
-      }  
-        if (month2 < 10) {  
-          month2 = '0' + month2;  
-        }  
-          
-          var t2 = year2 + '-' + month2 + '-' + day2;  
-          return t2;  
-      }  
+    var day2 = day;  
+    var days2 = new Date(year2, month2, 0);  
+    days2 = days2.getDate();  
+    if (day2 > days2) {  
+      day2 = days2;  
+    }  
+    if (month2 < 10) {  
+      month2 = '0' + month2;  
+    }       
+      var t2 = year2 + '-' + month2 + '-' + day2;  
+      return t2;   
   },
   getPreMonth(date) {  
     var arr = date.split('-');  
@@ -252,17 +250,17 @@ export default {
       year2 = parseInt(year2) - 1;  
       month2 = 12;  
     }  
-       var day2 = day;  
-       var days2 = new Date(year2, month2, 0);  
-       days2 = days2.getDate();  
-       if (day2 > days2) {  
-         day2 = days2;  
-       }  
-       if (month2 < 10) {  
-         month2 = '0' + month2;  
-       }  
-         var t2 = year2 + '-' + month2 + '-' + day2;  
-         return t2;  
+    var day2 = day;  
+    var days2 = new Date(year2, month2, 0);  
+    days2 = days2.getDate();  
+    if (day2 > days2) {  
+       day2 = days2;  
+    }  
+    if (month2 < 10) {  
+      month2 = '0' + month2;  
+    }  
+    var t2 = year2 + '-' + month2 + '-' + day2;  
+    return t2;  
   },
   watch: {
     value (newVal, oldVal) {

--- a/src/components/calendar/index.vue
+++ b/src/components/calendar/index.vue
@@ -141,6 +141,32 @@ export default {
     if (this.value === 'TODAY') {
       this.currentValue = format(new Date(), 'YYYY-MM-DD')
       this.$emit('input', this.currentValue)
+        } else if (this.value === 'NEXTMONTH') {
+      var date = new Date();
+      this.currentValue = this.getNextMonth(format(date,'YYYY-MM-DD'))
+      this.$emit('input', this.currentValue)
+    } else if (this.value === 'NEXTMONTH_FIRST') {
+      var date = new Date();
+      this.currentValue = this.getNextMonth(format(new Date(date.getFullYear(),date.getMonth(),1),'YYYY-MM-DD'))
+      this.$emit('input', this.currentValue)
+    } else if (this.value === 'NEXTMONTH_LAST'){
+      var date = new Date();
+      var days = new Date(date.getFullYear(),date.getMonth(),0).getDate();
+      this.currentValue = this.getNextMonth(format(new Date(date.getFullYear(),date.getMonth(),days),'YYYY-MM-DD'))
+      this.$emit('input', this.currentValue)
+    } else if (this.value === 'LASTMONTH') {
+      var date = new Date();
+      this.currentValue = this.getPreMonth(format(date),'YYYY-MM-DD'))
+      this.$emit('input', this.currentValue)
+    } else if (this.value === 'LASTMONTH_FIRST') {
+      var date = new Date();
+      this.currentValue = this.getPreMonth(format(new Date(date.getFullYear(),date.getMonth(),1),'YYYY-MM-DD'))
+      this.$emit('input', this.currentValue)
+    } else if (this.value === 'LASTMONTH_LAST'){
+      var date = new Date();
+      var days = new Date(date.getFullYear(),date.getMonth(),0).getDate();
+      this.currentValue = this.getPreMonth(format(new Date(date.getFullYear(),date.getMonth(),days),'YYYY-MM-DD'))
+      this.$emit('input', this.currentValue)
     } else {
       if (this.getType(this.value) === 'string') {
         this.currentValue = this.value
@@ -185,6 +211,58 @@ export default {
         this.show = false
       }
     }
+  },
+  getNextMonth(date) {  
+    var arr = date.split('-');  
+    var year = arr[0]; //获取当前日期的年份  
+    var month = arr[1]; //获取当前日期的月份  
+    var day = arr[2]; //获取当前日期的日  
+    var days = new Date(year, month, 0);  
+    days = days.getDate(); //获取当前日期中的月的天数  
+    var year2 = year;  
+    var month2 = parseInt(month) + 1;  
+    if (month2 == 13) {  
+    year2 = parseInt(year2) + 1;  
+      month2 = 1;  
+    }  
+      var day2 = day;  
+      var days2 = new Date(year2, month2, 0);  
+      days2 = days2.getDate();  
+      if (day2 > days2) {  
+        day2 = days2;  
+      }  
+        if (month2 < 10) {  
+          month2 = '0' + month2;  
+        }  
+          
+          var t2 = year2 + '-' + month2 + '-' + day2;  
+          return t2;  
+      }  
+  },
+  getPreMonth(date) {  
+    var arr = date.split('-');  
+    var year = arr[0]; //获取当前日期的年份  
+    var month = arr[1]; //获取当前日期的月份  
+    var day = arr[2]; //获取当前日期的日  
+    var days = new Date(year, month, 0);  
+    days = days.getDate(); //获取当前日期中月的天数  
+    var year2 = year;  
+    var month2 = parseInt(month) - 1;  
+    if (month2 == 0) {  
+      year2 = parseInt(year2) - 1;  
+      month2 = 12;  
+    }  
+       var day2 = day;  
+       var days2 = new Date(year2, month2, 0);  
+       days2 = days2.getDate();  
+       if (day2 > days2) {  
+         day2 = days2;  
+       }  
+       if (month2 < 10) {  
+         month2 = '0' + month2;  
+       }  
+         var t2 = year2 + '-' + month2 + '-' + day2;  
+         return t2;  
   },
   watch: {
     value (newVal, oldVal) {

--- a/src/components/calendar/index.vue
+++ b/src/components/calendar/index.vue
@@ -156,7 +156,7 @@ export default {
       this.$emit('input', this.currentValue)
     } else if (this.value === 'LASTMONTH') {
       var date = new Date();
-      this.currentValue = this.getPreMonth(format(date),'YYYY-MM-DD'))
+      this.currentValue = this.getPreMonth(format(date,'YYYY-MM-DD'))
       this.$emit('input', this.currentValue)
     } else if (this.value === 'LASTMONTH_FIRST') {
       var date = new Date();


### PR DESCRIPTION
当前日历组件初始化选定是TODAY，这里添加了可以初始化选定上个月、下个月、上个月月初、上个月月末、下个月月初、下个月月末，扩大初始化选定的范围。

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
