### PR TITLE
能够在v-chart渲染前做自定义设置

### DIFF
--- a/src/components/v-chart/v-chart.vue
+++ b/src/components/v-chart/v-chart.vue
@@ -447,6 +447,9 @@ export default {
           rs.size(seriesField || '', size)
         }
       }
+
+      // 在渲染前执触发on-render使之可以做自定义设置
+      this.$emit('on-render', { chart })
       chart.render()
       this.chart = chart
     }


### PR DESCRIPTION
由于现在v-chart不是完全支持f2的属性，比如chart.line().style(cfg) 无法实现，如果使用自定义渲染逻辑的话，那现在的v-line，v-scale这些组件就完全没有作用了，所以能不能在 chart.render() 前触发一下 on-render 事件，这样可以做渲染前最后的自定义设置

