### PR TITLE
【x-dialog】dialog若无指定z-index，则自动mask-z-index + 1

### DIFF
--- a/src/components/x-dialog/index.vue
+++ b/src/components/x-dialog/index.vue
@@ -6,7 +6,7 @@
       <div class="weui-mask" @click="hide" v-show="show" :style="maskStyle"></div>
     </transition>
     <transition :name="dialogTransition">
-      <div :class="dialogClass" v-show="show" :style="dialogStyle">
+      <div :class="dialogClass" v-show="show" :style="computedDialogStyle">
         <slot></slot>
       </div>
     </transition>
@@ -62,6 +62,16 @@ export default {
           zIndex: this.maskZIndex
         }
       }
+    },
+    computedDialogStyle () {
+      let ret = {};
+      if (typeof this.maskZIndex !== 'undefined') {
+        ret.zIndex = this.maskZIndex + 1;
+      }
+      if (JSON.stringify(this.dialogStyle) !== '{}') {
+        Object.assign(ret, this.dialogStyle);
+      }
+      return ret;
     }
   },
   mounted () {


### PR DESCRIPTION
x-dialog有mask-z-index屬性，但如果層級比dialog高會產生遮蓋
（主要因為confirm組件不支持dialog-style屬性，無法額外指定其z-index）

因此增加指定了mask-z-index屬性，則dialog的z-index為mask-z-index + 1
使用dialog-style指定dialog的z-index除外

Please makes sure the items are checked before submitting your PR, thank you!

* [ x ] `Rebase` before creating a PR to keep commit history clear.
* [ x ] `Only One commit`
* [ x ] No `eslint` errors
