### PR TITLE
Millent修复x-input type =number 在安卓qq浏览器下 v-model 绑定无效

### DIFF
--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="vux-x-input weui-cell"
-       :class="{
+	<div class="vux-x-input weui-cell"
+		:class="{
 			'weui-cell_warn': showWarn,
 			'disabled': disabled,
 			'vux-x-input-has-right-full': hasRightFullHeightSlot
@@ -16,110 +16,110 @@
     </div>
     <div class="weui-cell__bd weui-cell__primary" :class="placeholderAlign ? `vux-x-input-placeholder-${placeholderAlign}` : ''">
       <input
-        :id="`vux-x-input-${uuid}`"
-        v-if="!type || type === 'text'"
-        class="weui-input"
-        :maxlength="max"
-        :autocomplete="autocomplete"
-        :autocapitalize="autocapitalize"
-        :autocorrect="autocorrect"
-        :spellcheck="spellcheck"
-        :style="inputStyle"
-        type="text"
-        :name="name"
-        :pattern="pattern"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        :disabled="disabled"
-        v-model="currentValue"
-        @focus="focusHandler"
-        @blur="onBlur"
-        @keyup="onKeyUp"
-        ref="input"/>
+      :id="`vux-x-input-${uuid}`"
+      v-if="!type || type === 'text'"
+      class="weui-input"
+      :maxlength="max"
+      :autocomplete="autocomplete"
+      :autocapitalize="autocapitalize"
+      :autocorrect="autocorrect"
+      :spellcheck="spellcheck"
+      :style="inputStyle"
+      type="text"
+      :name="name"
+      :pattern="pattern"
+      :placeholder="placeholder"
+      :readonly="readonly"
+      :disabled="disabled"
+      v-model="currentValue"
+      @focus="focusHandler"
+      @blur="onBlur"
+      @keyup="onKeyUp"
+      ref="input"/>
       <input
-        :id="`vux-x-input-${uuid}`"
-        v-if="type === 'number'"
-        class="weui-input"
-        :maxlength="max"
-        :autocomplete="autocomplete"
-        :autocapitalize="autocapitalize"
-        :autocorrect="autocorrect"
-        :spellcheck="spellcheck"
-        :style="inputStyle"
-        type="number"
-        :name="name"
-        :pattern="pattern"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        :disabled="disabled"
-        v-model="currentValue"
-        @focus="focusHandler"
-        @blur="onBlur"
-        @keyup="onKeyUp"
-        ref="input"/>
+      :id="`vux-x-input-${uuid}`"
+      v-if="type === 'number'"
+      class="weui-input"
+      :maxlength="max"
+      :autocomplete="autocomplete"
+      :autocapitalize="autocapitalize"
+      :autocorrect="autocorrect"
+      :spellcheck="spellcheck"
+      :style="inputStyle"
+      type="number"
+      :name="name"
+      :pattern="pattern"
+      :placeholder="placeholder"
+      :readonly="readonly"
+      :disabled="disabled"
+      v-model="currentValue"
+      @focus="focusHandler"
+      @blur="onBlur"
+      @keyup="onKeyUp"
+      ref="input"/>
       <input
-        :id="`vux-x-input-${uuid}`"
-        v-if="type === 'email'"
-        class="weui-input"
-        :maxlength="max"
-        :autocomplete="autocomplete"
-        :autocapitalize="autocapitalize"
-        :autocorrect="autocorrect"
-        :spellcheck="spellcheck"
-        :style="inputStyle"
-        type="email"
-        :name="name"
-        :pattern="pattern"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        :disabled="disabled"
-        v-model="currentValue"
-        @focus="focusHandler"
-        @blur="onBlur"
-        @keyup="onKeyUp"
-        ref="input"/>
+      :id="`vux-x-input-${uuid}`"
+      v-if="type === 'email'"
+      class="weui-input"
+      :maxlength="max"
+      :autocomplete="autocomplete"
+      :autocapitalize="autocapitalize"
+      :autocorrect="autocorrect"
+      :spellcheck="spellcheck"
+      :style="inputStyle"
+      type="email"
+      :name="name"
+      :pattern="pattern"
+      :placeholder="placeholder"
+      :readonly="readonly"
+      :disabled="disabled"
+      v-model="currentValue"
+      @focus="focusHandler"
+      @blur="onBlur"
+      @keyup="onKeyUp"
+      ref="input"/>
       <input
-        :id="`vux-x-input-${uuid}`"
-        v-if="type === 'password'"
-        class="weui-input"
-        :maxlength="max"
-        :autocomplete="autocomplete"
-        :autocapitalize="autocapitalize"
-        :autocorrect="autocorrect"
-        :spellcheck="spellcheck"
-        :style="inputStyle"
-        type="password"
-        :name="name"
-        :pattern="pattern"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        :disabled="disabled"
-        v-model="currentValue"
-        @focus="focusHandler"
-        @blur="onBlur"
-        @keyup="onKeyUp"
-        ref="input"/>
+      :id="`vux-x-input-${uuid}`"
+      v-if="type === 'password'"
+      class="weui-input"
+      :maxlength="max"
+      :autocomplete="autocomplete"
+      :autocapitalize="autocapitalize"
+      :autocorrect="autocorrect"
+      :spellcheck="spellcheck"
+      :style="inputStyle"
+      type="password"
+      :name="name"
+      :pattern="pattern"
+      :placeholder="placeholder"
+      :readonly="readonly"
+      :disabled="disabled"
+      v-model="currentValue"
+      @focus="focusHandler"
+      @blur="onBlur"
+      @keyup="onKeyUp"
+      ref="input"/>
       <input
-        :id="`vux-x-input-${uuid}`"
-        v-if="type === 'tel'"
-        class="weui-input"
-        :maxlength="max"
-        :autocomplete="autocomplete"
-        :autocapitalize="autocapitalize"
-        :autocorrect="autocorrect"
-        :spellcheck="spellcheck"
-        :style="inputStyle"
-        type="tel"
-        :name="name"
-        :pattern="pattern"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        :disabled="disabled"
-        v-model="currentValue"
-        @focus="focusHandler"
-        @blur="onBlur"
-        @keyup="onKeyUp"
-        ref="input"/>
+      :id="`vux-x-input-${uuid}`"
+      v-if="type === 'tel'"
+      class="weui-input"
+      :maxlength="max"
+      :autocomplete="autocomplete"
+      :autocapitalize="autocapitalize"
+      :autocorrect="autocorrect"
+      :spellcheck="spellcheck"
+      :style="inputStyle"
+      type="tel"
+      :name="name"
+      :pattern="pattern"
+      :placeholder="placeholder"
+      :readonly="readonly"
+      :disabled="disabled"
+      v-model="currentValue"
+      @focus="focusHandler"
+      @blur="onBlur"
+      @keyup="onKeyUp"
+      ref="input"/>
     </div>
     <div class="weui-cell__ft">
       <icon type="clear" v-show="!hasRightFullHeightSlot && !equalWith && showClear && currentValue !== '' && !readonly && !disabled && isFocus" @click.native="clear"></icon>
@@ -139,489 +139,487 @@
     </div>
 
     <toast
-      v-model="showErrorToast"
-      type="text"
-      width="auto"
-      :time="600">{{ firstError }}</toast>
+    v-model="showErrorToast"
+    type="text"
+    width="auto"
+    :time="600">{{ firstError }}</toast>
   </div>
 </template>
 
 <script>
-  import Base from '../../libs/base'
-  import Icon from '../icon'
-  import Toast from '../toast'
-  import InlineDesc from '../inline-desc'
+import Base from '../../libs/base'
+import Icon from '../icon'
+import Toast from '../toast'
+import InlineDesc from '../inline-desc'
 
-  import isEmail from 'validator/lib/isEmail'
-  import isMobilePhone from 'validator/lib/isMobilePhone'
+import isEmail from 'validator/lib/isEmail'
+import isMobilePhone from 'validator/lib/isMobilePhone'
 
-  import Debounce from '../../tools/debounce'
+import Debounce from '../../tools/debounce'
 
-  import mask from 'vanilla-masker'
+import mask from 'vanilla-masker'
 
-  const validators = {
-    'email': {
-      fn: isEmail,
-      msg: '邮箱格式'
+const validators = {
+  'email': {
+    fn: isEmail,
+    msg: '邮箱格式'
+  },
+  'china-mobile': {
+    fn (str) {
+      return isMobilePhone(str, 'zh-CN')
     },
-    'china-mobile': {
-      fn (str) {
-        return isMobilePhone(str, 'zh-CN')
-      },
-      msg: '手机号码'
+    msg: '手机号码'
+  },
+  'china-name': {
+    fn (str) {
+      return str.length >= 2 && str.length <= 6
     },
-    'china-name': {
-      fn (str) {
-        return str.length >= 2 && str.length <= 6
-      },
-      msg: '中文姓名'
-    }
+    msg: '中文姓名'
   }
-  export default {
-    name: 'x-input',
-    created () {
-      this.currentValue = (this.value === undefined || this.value === null) ? '' : (this.mask ? this.maskValue(this.value) : this.value)
-      /* istanbul ignore if */
-      if (process.env.NODE_ENV === 'development') {
-        if (!this.title && !this.placeholder && !this.currentValue) {
-          console.warn('no title and no placeholder?')
-        }
+}
+export default {
+  name: 'x-input',
+  created () {
+    this.currentValue = (this.value === undefined || this.value === null) ? '' : (this.mask ? this.maskValue(this.value) : this.value)
+    /* istanbul ignore if */
+    if (process.env.NODE_ENV === 'development') {
+      if (!this.title && !this.placeholder && !this.currentValue) {
+        console.warn('no title and no placeholder?')
       }
+    }
 
-      if (this.required && (typeof this.currentValue === 'undefined' || this.currentValue === '')) {
-        this.valid = false
-      }
-      this.handleChangeEvent = true
-      if (this.debounce) {
-        this._debounce = Debounce(() => {
-          this.$emit('on-change', this.currentValue)
-        }, this.debounce)
+    if (this.required && (typeof this.currentValue === 'undefined' || this.currentValue === '')) {
+      this.valid = false
+    }
+    this.handleChangeEvent = true
+    if (this.debounce) {
+      this._debounce = Debounce(() => {
+        this.$emit('on-change', this.currentValue)
+      }, this.debounce)
+    }
+  },
+  beforeMount () {
+    if (this.$slots && this.$slots['restricted-label']) {
+      this.hasRestrictedLabel = true
+    }
+    if (this.$slots && this.$slots['right-full-height']) {
+      this.hasRightFullHeightSlot = true
+    }
+  },
+  beforeDestroy () {
+    if (this._debounce) {
+      this._debounce.cancel()
+    }
+    window.removeEventListener('resize', this.scrollIntoView)
+  },
+  mixins: [Base],
+  components: {
+    Icon,
+    InlineDesc,
+    Toast
+  },
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    type: {
+      type: String,
+      default: 'text'
+    },
+    placeholder: String,
+    value: [String, Number],
+    name: String,
+    readonly: Boolean,
+    disabled: Boolean,
+    keyboard: String,
+    inlineDesc: String,
+    isType: [String, Function],
+    min: Number,
+    max: Number,
+    showClear: {
+      type: Boolean,
+      default: true
+    },
+    equalWith: String,
+    textAlign: String,
+    // https://github.com/yisibl/blog/issues/3
+    autocomplete: {
+      type: String,
+      default: 'off'
+    },
+    autocapitalize: {
+      type: String,
+      default: 'off'
+    },
+    autocorrect: {
+      type: String,
+      default: 'off'
+    },
+    spellcheck: {
+      type: String,
+      default: 'false'
+    },
+    novalidate: {
+      type: Boolean,
+      default: false
+    },
+    iconType: String,
+    debounce: Number,
+    placeholderAlign: String,
+    labelWidth: String,
+    mask: String,
+    shouldToastError: {
+      type: Boolean,
+      default: true
+    }
+  },
+  computed: {
+    labelStyles () {
+      return {
+        width: this.labelWidthComputed || this.$parent.labelWidth || this.labelWidthComputed,
+        textAlign: this.$parent.labelAlign,
+        marginRight: this.$parent.labelMarginRight
       }
     },
-    beforeMount () {
-      if (this.$slots && this.$slots['restricted-label']) {
-        this.hasRestrictedLabel = true
-      }
-      if (this.$slots && this.$slots['right-full-height']) {
-        this.hasRightFullHeightSlot = true
+    labelClass () {
+      return {
+        'vux-cell-justify': this.$parent.labelAlign === 'justify' || this.$parent.$parent.labelAlign === 'justify'
       }
     },
-    beforeDestroy () {
-      if (this._debounce) {
-        this._debounce.cancel()
-      }
-      window.removeEventListener('resize', this.scrollIntoView)
-    },
-    mixins: [Base],
-    components: {
-      Icon,
-      InlineDesc,
-      Toast
-    },
-    props: {
-      title: {
-        type: String,
-        default: ''
-      },
-      type: {
-        type: String,
-        default: 'text'
-      },
-      placeholder: String,
-      value: [String, Number],
-      name: String,
-      readonly: Boolean,
-      disabled: Boolean,
-      keyboard: String,
-      inlineDesc: String,
-      isType: [String, Function],
-      min: Number,
-      max: Number,
-      showClear: {
-        type: Boolean,
-        default: true
-      },
-      equalWith: String,
-      textAlign: String,
-      // https://github.com/yisibl/blog/issues/3
-      autocomplete: {
-        type: String,
-        default: 'off'
-      },
-      autocapitalize: {
-        type: String,
-        default: 'off'
-      },
-      autocorrect: {
-        type: String,
-        default: 'off'
-      },
-      spellcheck: {
-        type: String,
-        default: 'false'
-      },
-      novalidate: {
-        type: Boolean,
-        default: false
-      },
-      iconType: String,
-      debounce: Number,
-      placeholderAlign: String,
-      labelWidth: String,
-      mask: String,
-      shouldToastError: {
-        type: Boolean,
-        default: true
+    pattern () {
+      if (this.keyboard === 'number' || this.isType === 'china-mobile') {
+        return '[0-9]*'
       }
     },
-    computed: {
-      labelStyles () {
+    labelWidthComputed () {
+      const width = this.title.replace(/[^x00-xff]/g, '00').length / 2 + 1
+      if (width < 10) {
+        return width + 'em'
+      }
+    },
+    hasErrors () {
+      return Object.keys(this.errors).length > 0
+    },
+    inputStyle () {
+      if (this.textAlign) {
         return {
-          width: this.labelWidthComputed || this.$parent.labelWidth || this.labelWidthComputed,
-          textAlign: this.$parent.labelAlign,
-          marginRight: this.$parent.labelMarginRight
+          textAlign: this.textAlign
         }
-      },
-      labelClass () {
-        return {
-          'vux-cell-justify': this.$parent.labelAlign === 'justify' || this.$parent.$parent.labelAlign === 'justify'
-        }
-      },
-      pattern () {
-        if (this.keyboard === 'number' || this.isType === 'china-mobile') {
-          return '[0-9]*'
-        }
-      },
-      labelWidthComputed () {
-        const width = this.title.replace(/[^x00-xff]/g, '00').length / 2 + 1
-        if (width < 10) {
-          return width + 'em'
-        }
-      },
-      hasErrors () {
-        return Object.keys(this.errors).length > 0
-      },
-      inputStyle () {
-        if (this.textAlign) {
-          return {
-            textAlign: this.textAlign
-          }
-        }
-      },
-      showWarn () {
-        return !this.novalidate && !this.equalWith && !this.valid && this.firstError && (this.touched || this.forceShowError)
       }
     },
-    mounted () {
-      window.addEventListener('resize', this.scrollIntoView)
-    },
-    methods: {
-      scrollIntoView (time = 0) {
-        // alert('scroll into view')
-        if (/iphone/i.test(navigator.userAgent)) {
-          // return
-        }
-        if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
-          // alert('will scroll')
-          setTimeout(() => {
-            // alert(this.$refs.input.length)
-            this.$refs.input.scrollIntoViewIfNeeded(true)
-          }, time)
-        }
-      },
-      onClickErrorIcon () {
-        if (this.shouldToastError && this.firstError) {
-          this.showErrorToast = true
-        }
-        this.$emit('on-click-error-icon', this.firstError)
-      },
-      maskValue (val) {
-        const val1 = this.mask ? mask.toPattern(val, this.mask) : val
-        return val1
-      },
-      reset (value = '') {
-        this.dirty = false
-        this.currentValue = value
-        this.firstError = ''
-        this.valid = true
-      },
-      clear () {
-        this.currentValue = ''
-        this.focus()
-        this.$emit('on-click-clear-icon')
-      },
-      focus () {
-        this.$refs.input.focus()
-      },
-      blur () {
-        this.$refs.input.blur()
-      },
-      focusHandler ($event) {
-        this.$emit('on-focus', this.currentValue, $event)
-        this.isFocus = true
-        // this.scrollIntoView(500)
-        // this.scrollIntoView(5000)
+    showWarn () {
+      return !this.novalidate && !this.equalWith && !this.valid && this.firstError && (this.touched || this.forceShowError)
+    }
+  },
+  mounted () {
+    window.addEventListener('resize', this.scrollIntoView)
+  },
+  methods: {
+    scrollIntoView (time = 0) {
+      // alert('scroll into view')
+      if (/iphone/i.test(navigator.userAgent)) {
+        // return
+      }
+      if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
+        // alert('will scroll')
         setTimeout(() => {
-          this.$refs.input.scrollIntoViewIfNeeded(false)
-          // this.$refs.input.scrollIntoViewIfNeeded()
-        }, 1000)
-        // $event.target.
-      },
-      onBlur ($event) {
-        this.setTouched()
-        this.validate()
-        this.isFocus = false
-        this.$emit('on-blur', this.currentValue, $event)
-      },
-      onKeyUp (e) {
-        if (e.key === 'Enter') {
-          e.target.blur()
-          this.$emit('on-enter', this.currentValue, e)
-        }
-      },
-      getError () {
-        let key = Object.keys(this.errors)[0]
-        this.firstError = this.errors[key]
-      },
-      validate () {
-        if (typeof this.equalWith !== 'undefined') {
-          this.validateEqual()
-          return
-        }
-        this.errors = {}
+          // alert(this.$refs.input.length)
+          this.$refs.input.scrollIntoViewIfNeeded(true)
+        }, time)
+      }
+    },
+    onClickErrorIcon () {
+      if (this.shouldToastError && this.firstError) {
+        this.showErrorToast = true
+      }
+      this.$emit('on-click-error-icon', this.firstError)
+    },
+    maskValue (val) {
+      const val1 = this.mask ? mask.toPattern(val, this.mask) : val
+      return val1
+    },
+    reset (value = '') {
+      this.dirty = false
+      this.currentValue = value
+      this.firstError = ''
+      this.valid = true
+    },
+    clear () {
+      this.currentValue = ''
+      this.focus()
+      this.$emit('on-click-clear-icon')
+    },
+    focus () {
+      this.$refs.input.focus()
+    },
+    blur () {
+      this.$refs.input.blur()
+    },
+    focusHandler ($event) {
+      this.$emit('on-focus', this.currentValue, $event)
+      this.isFocus = true
+      // this.scrollIntoView(500)
+      // this.scrollIntoView(5000)
+      setTimeout(() => {
+        this.$refs.input.scrollIntoViewIfNeeded(false)
+        // this.$refs.input.scrollIntoViewIfNeeded()
+      }, 1000)
+      // $event.target.
+    },
+    onBlur ($event) {
+      this.setTouched()
+      this.validate()
+      this.isFocus = false
+      this.$emit('on-blur', this.currentValue, $event)
+    },
+    onKeyUp (e) {
+      if (e.key === 'Enter') {
+        e.target.blur()
+        this.$emit('on-enter', this.currentValue, e)
+      }
+    },
+    getError () {
+      let key = Object.keys(this.errors)[0]
+      this.firstError = this.errors[key]
+    },
+    validate () {
+      if (typeof this.equalWith !== 'undefined') {
+        this.validateEqual()
+        return
+      }
+      this.errors = {}
 
-        if (!this.currentValue && !this.required) {
-          this.valid = true
-          return
-        }
+      if (!this.currentValue && !this.required) {
+        this.valid = true
+        return
+      }
 
-        if (!this.currentValue && this.required) {
-          this.valid = false
-          this.errors.required = '必填哦'
-          this.getError()
-          return
-        }
+      if (!this.currentValue && this.required) {
+        this.valid = false
+        this.errors.required = '必填哦'
+        this.getError()
+        return
+      }
 
-        if (typeof this.isType === 'string') {
-          const validator = validators[this.isType]
-          if (validator) {
-            let value = this.currentValue
+      if (typeof this.isType === 'string') {
+        const validator = validators[this.isType]
+        if (validator) {
+          let value = this.currentValue
 
-            if (this.isType === 'china-mobile' && this.mask === '999 9999 9999') {
-              value = this.currentValue.replace(/\s+/g, '')
-            }
-
-            this.valid = validator[ 'fn' ](value)
-            if (!this.valid) {
-              this.forceShowError = true
-              this.errors.format = validator[ 'msg' ] + '格式不对哦~'
-              this.getError()
-              return
-            } else {
-              delete this.errors.format
-            }
+          if (this.isType === 'china-mobile' && this.mask === '999 9999 9999') {
+            value = this.currentValue.replace(/\s+/g, '')
           }
-        }
 
-        if (typeof this.isType === 'function') {
-          const validStatus = this.isType(this.currentValue)
-          this.valid = validStatus.valid
+          this.valid = validator[ 'fn' ](value)
           if (!this.valid) {
-            this.errors.format = validStatus.msg
             this.forceShowError = true
+            this.errors.format = validator[ 'msg' ] + '格式不对哦~'
             this.getError()
             return
           } else {
             delete this.errors.format
           }
         }
+      }
 
-        if (this.min) {
-          if (this.currentValue.length < this.min) {
-            this.errors.min = `最少应该输入${this.min}个字符哦`
-            this.valid = false
-            this.getError()
-            return
-          } else {
-            delete this.errors.min
-          }
-        }
-
-        if (this.max) {
-          if (this.currentValue.length > this.max) {
-            this.errors.max = `最多可以输入${this.max}个字符哦`
-            this.valid = false
-            this.forceShowError = true
-            return
-          } else {
-            this.forceShowError = false
-            delete this.errors.max
-          }
-        }
-
-        this.valid = true
-      },
-      validateEqual () {
-        if (!this.equalWith && this.currentValue) {
-          this.valid = false
-          this.errors.equal = '输入不一致'
-          return
-        }
-        let willCheck = this.dirty || this.currentValue.length >= this.equalWith.length
-        // 只在长度符合时显示正确与否
-        if (willCheck && this.currentValue !== this.equalWith) {
-          this.valid = false
-          this.errors.equal = '输入不一致'
+      if (typeof this.isType === 'function') {
+        const validStatus = this.isType(this.currentValue)
+        this.valid = validStatus.valid
+        if (!this.valid) {
+          this.errors.format = validStatus.msg
+          this.forceShowError = true
+          this.getError()
           return
         } else {
-          if (!this.currentValue && this.required) {
-            this.valid = false
-          } else {
-            this.valid = true
-            delete this.errors.equal
-          }
+          delete this.errors.format
         }
-      },
-      // #2810
-      _getInputMaskSelection (selection, direction, maskVal, loop) {
-        if (!this.mask || (loop && direction === 0)) {
-          return selection
+      }
+
+      if (this.min) {
+        if (this.currentValue.length < this.min) {
+          this.errors.min = `最少应该输入${this.min}个字符哦`
+          this.valid = false
+          this.getError()
+          return
+        } else {
+          delete this.errors.min
         }
-        if (direction === 0) {
-          direction = this.lastDirection
+      }
+
+      if (this.max) {
+        if (this.currentValue.length > this.max) {
+          this.errors.max = `最多可以输入${this.max}个字符哦`
+          this.valid = false
+          this.forceShowError = true
+          return
+        } else {
+          this.forceShowError = false
+          delete this.errors.max
         }
-        if (direction > 0) {
-          const maskChar = this.mask.substr(selection - direction, 1)
-          if (!maskChar.match(/[9SA]/)) {
-            return this._getInputMaskSelection(selection + 1, direction, maskVal, true)
-          }
+      }
+
+      this.valid = true
+    },
+    validateEqual () {
+      if (!this.equalWith && this.currentValue) {
+        this.valid = false
+        this.errors.equal = '输入不一致'
+        return
+      }
+      let willCheck = this.dirty || this.currentValue.length >= this.equalWith.length
+      // 只在长度符合时显示正确与否
+      if (willCheck && this.currentValue !== this.equalWith) {
+        this.valid = false
+        this.errors.equal = '输入不一致'
+        return
+      } else {
+        if (!this.currentValue && this.required) {
+          this.valid = false
+        } else {
+          this.valid = true
+          delete this.errors.equal
         }
+      }
+    },
+    // #2810
+    _getInputMaskSelection (selection, direction, maskVal, loop) {
+      if (!this.mask || (loop && direction === 0)) {
         return selection
       }
-    },
-    data () {
-      return {
-        hasRightFullHeightSlot: false,
-        hasRestrictedLabel: false,
-        firstError: '',
-        forceShowError: false,
-        hasLengthEqual: false,
-        valid: true,
-        currentValue: '',
-        showErrorToast: false,
-        isFocus: false
+      if (direction === 0) {
+        direction = this.lastDirection
+      }
+      if (direction > 0) {
+        const maskChar = this.mask.substr(selection - direction, 1)
+        if (!maskChar.match(/[9SA]/)) {
+          return this._getInputMaskSelection(selection + 1, direction, maskVal, true)
+        }
+      }
+      return selection
+    }
+  },
+  data () {
+    return {
+      hasRightFullHeightSlot: false,
+      hasRestrictedLabel: false,
+      firstError: '',
+      forceShowError: false,
+      hasLengthEqual: false,
+      valid: true,
+      currentValue: '',
+      showErrorToast: false,
+      isFocus: false
+    }
+  },
+  watch: {
+    mask (val) {
+      if (val && this.currentValue) {
+        this.currentValue = this.maskValue(this.currentValue)
       }
     },
-    watch: {
-      mask (val) {
-        if (val && this.currentValue) {
-          this.currentValue = this.maskValue(this.currentValue)
+    valid () {
+      this.getError()
+    },
+    value (val) {
+      this.currentValue = val
+    },
+    equalWith (newVal) {
+      if (newVal && this.equalWith) {
+        if (newVal.length === this.equalWith.length) {
+          this.hasLengthEqual = true
         }
-      },
-      valid () {
-        this.getError()
-      },
-      value (val) {
-        this.currentValue = val
-      },
-      equalWith (newVal) {
-        if (newVal && this.equalWith) {
-          if (newVal.length === this.equalWith.length) {
-            this.hasLengthEqual = true
-          }
-          this.validateEqual()
-        } else {
-          this.validate()
+        this.validateEqual()
+      } else {
+        this.validate()
+      }
+    },
+    currentValue (newVal, oldVal) {
+      let selection = null
+      if (!this.equalWith && newVal) {
+        this.validateEqual()
+      }
+      if (newVal && this.equalWith) {
+        if (newVal.length === this.equalWith.length) {
+          this.hasLengthEqual = true
         }
-      },
-      currentValue (newVal, oldVal) {
-        let selection = null
-        if (!this.equalWith && newVal) {
-          this.validateEqual()
+        this.validateEqual()
+      } else {
+        this.validate()
+      }
+      // #2960
+      try {
+        selection = this.$refs.input.selectionStart
+        let direction = newVal.length - oldVal.length
+        selection = this._getInputMaskSelection(selection, direction, this.maskValue(newVal))
+        this.lastDirection = direction
+      } catch (e) {}
+      this.$emit('input', this.maskValue(newVal))
+      // #2810
+      this.$nextTick(() => {
+        if (this.$refs.input.selectionStart !== selection) {
+          this.$refs.input.selectionStart = selection
+          this.$refs.input.selectionEnd = selection
         }
-        if (newVal && this.equalWith) {
-          if (newVal.length === this.equalWith.length) {
-            this.hasLengthEqual = true
-          }
-          this.validateEqual()
-        } else {
-          this.validate()
+        if (this.currentValue !== this.maskValue(newVal)) {
+          this.currentValue = this.maskValue(newVal)
         }
-        // #2960
-        try {
-          selection = this.$refs.input.selectionStart
-          let direction = newVal.length - oldVal.length
-          selection = this._getInputMaskSelection(selection, direction, this.maskValue(newVal))
-          this.lastDirection = direction
-        } catch (e) {
+      })
 
-        }
-        this.$emit('input', this.maskValue(newVal))
-        // #2810
-        this.$nextTick(() => {
-          if (this.$refs.input.selectionStart !== selection) {
-            this.$refs.input.selectionStart = selection
-            this.$refs.input.selectionEnd = selection
-          }
-          if (this.currentValue !== this.maskValue(newVal)) {
-            this.currentValue = this.maskValue(newVal)
-          }
-        })
-
-        if (this._debounce) {
-          this._debounce()
-        } else {
-          this.$emit('on-change', newVal)
-        }
+      if (this._debounce) {
+        this._debounce()
+      } else {
+        this.$emit('on-change', newVal)
       }
     }
   }
+}
 </script>
 
 <style lang="less">
-  @import '../../styles/weui/widget/weui_cell/weui_access';
-  @import '../../styles/weui/widget/weui_cell/weui_cell_global';
-  @import '../../styles/weui/widget/weui_cell/weui_form/weui_form_common';
-  @import '../../styles/weui/widget/weui_cell/weui_form/weui_vcode';
+@import '../../styles/weui/widget/weui_cell/weui_access';
+@import '../../styles/weui/widget/weui_cell/weui_cell_global';
+@import '../../styles/weui/widget/weui_cell/weui_form/weui_form_common';
+@import '../../styles/weui/widget/weui_cell/weui_form/weui_vcode';
 
-  .vux-x-input .vux-x-input-placeholder-right input::-webkit-input-placeholder {
-    text-align: right;
+.vux-x-input .vux-x-input-placeholder-right input::-webkit-input-placeholder {
+  text-align: right;
+}
+.vux-x-input .vux-x-input-placeholder-center input::-webkit-input-placeholder {
+  text-align: center;
+}
+.vux-x-input .vux-input-icon {
+  font-size: 21px;
+}
+.vux-input-icon.weui-icon-warn:before, .vux-input-icon.weui-icon-success:before {
+  font-size: 21px;
+}
+.vux-x-input .weui-icon {
+  padding-left: 5px;
+}
+.vux-x-input.weui-cell_vcode {
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+}
+.vux-x-input.disabled {
+  .weui-input {
+    text-fill-color: #888;
+    -webkit-text-fill-color: #888; /* Override iOS / Android font color change */
+    opacity: 1; /* Override iOS opacity change affecting text & background color */
   }
-  .vux-x-input .vux-x-input-placeholder-center input::-webkit-input-placeholder {
-    text-align: center;
-  }
-  .vux-x-input .vux-input-icon {
-    font-size: 21px;
-  }
-  .vux-input-icon.weui-icon-warn:before, .vux-input-icon.weui-icon-success:before {
-    font-size: 21px;
-  }
-  .vux-x-input .weui-icon {
-    padding-left: 5px;
-  }
-  .vux-x-input.weui-cell_vcode {
-    padding-top: 0;
-    padding-right: 0;
-    padding-bottom: 0;
-  }
-  .vux-x-input.disabled {
-    .weui-input {
-      text-fill-color: #888;
-      -webkit-text-fill-color: #888; /* Override iOS / Android font color change */
-      opacity: 1; /* Override iOS opacity change affecting text & background color */
-    }
-  }
-  .vux-x-input-right-full {
-    margin-left: 5px;
-    height: @weuiCellHeight;
-    vertical-align: middle;
-    & img {
-      height: @weuiCellHeight;
-    }
-  }
-  .vux-x-input-has-right-full {
-    padding-top: 0;
-    padding-right: 0;
-    padding-bottom: 0;
-  }
+}
+.vux-x-input-right-full {
+  margin-left: 5px;
+  height: @weuiCellHeight;
+  vertical-align: middle;
+	& img {
+		height: @weuiCellHeight;
+	}
+}
+.vux-x-input-has-right-full {
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+}
 </style>

--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="vux-x-input weui-cell"
-		:class="{
+  <div class="vux-x-input weui-cell"
+       :class="{
 			'weui-cell_warn': showWarn,
 			'disabled': disabled,
 			'vux-x-input-has-right-full': hasRightFullHeightSlot
@@ -16,110 +16,110 @@
     </div>
     <div class="weui-cell__bd weui-cell__primary" :class="placeholderAlign ? `vux-x-input-placeholder-${placeholderAlign}` : ''">
       <input
-      :id="`vux-x-input-${uuid}`"
-      v-if="!type || type === 'text'"
-      class="weui-input"
-      :maxlength="max"
-      :autocomplete="autocomplete"
-      :autocapitalize="autocapitalize"
-      :autocorrect="autocorrect"
-      :spellcheck="spellcheck"
-      :style="inputStyle"
-      type="text"
-      :name="name"
-      :pattern="pattern"
-      :placeholder="placeholder"
-      :readonly="readonly"
-      :disabled="disabled"
-      v-model="currentValue"
-      @focus="focusHandler"
-      @blur="onBlur"
-      @keyup="onKeyUp"
-      ref="input"/>
+        :id="`vux-x-input-${uuid}`"
+        v-if="!type || type === 'text'"
+        class="weui-input"
+        :maxlength="max"
+        :autocomplete="autocomplete"
+        :autocapitalize="autocapitalize"
+        :autocorrect="autocorrect"
+        :spellcheck="spellcheck"
+        :style="inputStyle"
+        type="text"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :disabled="disabled"
+        v-model="currentValue"
+        @focus="focusHandler"
+        @blur="onBlur"
+        @keyup="onKeyUp"
+        ref="input"/>
       <input
-      :id="`vux-x-input-${uuid}`"
-      v-if="type === 'number'"
-      class="weui-input"
-      :maxlength="max"
-      :autocomplete="autocomplete"
-      :autocapitalize="autocapitalize"
-      :autocorrect="autocorrect"
-      :spellcheck="spellcheck"
-      :style="inputStyle"
-      type="number"
-      :name="name"
-      :pattern="pattern"
-      :placeholder="placeholder"
-      :readonly="readonly"
-      :disabled="disabled"
-      v-model="currentValue"
-      @focus="focusHandler"
-      @blur="onBlur"
-      @keyup="onKeyUp"
-      ref="input"/>
+        :id="`vux-x-input-${uuid}`"
+        v-if="type === 'number'"
+        class="weui-input"
+        :maxlength="max"
+        :autocomplete="autocomplete"
+        :autocapitalize="autocapitalize"
+        :autocorrect="autocorrect"
+        :spellcheck="spellcheck"
+        :style="inputStyle"
+        type="number"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :disabled="disabled"
+        v-model="currentValue"
+        @focus="focusHandler"
+        @blur="onBlur"
+        @keyup="onKeyUp"
+        ref="input"/>
       <input
-      :id="`vux-x-input-${uuid}`"
-      v-if="type === 'email'"
-      class="weui-input"
-      :maxlength="max"
-      :autocomplete="autocomplete"
-      :autocapitalize="autocapitalize"
-      :autocorrect="autocorrect"
-      :spellcheck="spellcheck"
-      :style="inputStyle"
-      type="email"
-      :name="name"
-      :pattern="pattern"
-      :placeholder="placeholder"
-      :readonly="readonly"
-      :disabled="disabled"
-      v-model="currentValue"
-      @focus="focusHandler"
-      @blur="onBlur"
-      @keyup="onKeyUp"
-      ref="input"/>
+        :id="`vux-x-input-${uuid}`"
+        v-if="type === 'email'"
+        class="weui-input"
+        :maxlength="max"
+        :autocomplete="autocomplete"
+        :autocapitalize="autocapitalize"
+        :autocorrect="autocorrect"
+        :spellcheck="spellcheck"
+        :style="inputStyle"
+        type="email"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :disabled="disabled"
+        v-model="currentValue"
+        @focus="focusHandler"
+        @blur="onBlur"
+        @keyup="onKeyUp"
+        ref="input"/>
       <input
-      :id="`vux-x-input-${uuid}`"
-      v-if="type === 'password'"
-      class="weui-input"
-      :maxlength="max"
-      :autocomplete="autocomplete"
-      :autocapitalize="autocapitalize"
-      :autocorrect="autocorrect"
-      :spellcheck="spellcheck"
-      :style="inputStyle"
-      type="password"
-      :name="name"
-      :pattern="pattern"
-      :placeholder="placeholder"
-      :readonly="readonly"
-      :disabled="disabled"
-      v-model="currentValue"
-      @focus="focusHandler"
-      @blur="onBlur"
-      @keyup="onKeyUp"
-      ref="input"/>
+        :id="`vux-x-input-${uuid}`"
+        v-if="type === 'password'"
+        class="weui-input"
+        :maxlength="max"
+        :autocomplete="autocomplete"
+        :autocapitalize="autocapitalize"
+        :autocorrect="autocorrect"
+        :spellcheck="spellcheck"
+        :style="inputStyle"
+        type="password"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :disabled="disabled"
+        v-model="currentValue"
+        @focus="focusHandler"
+        @blur="onBlur"
+        @keyup="onKeyUp"
+        ref="input"/>
       <input
-      :id="`vux-x-input-${uuid}`"
-      v-if="type === 'tel'"
-      class="weui-input"
-      :maxlength="max"
-      :autocomplete="autocomplete"
-      :autocapitalize="autocapitalize"
-      :autocorrect="autocorrect"
-      :spellcheck="spellcheck"
-      :style="inputStyle"
-      type="tel"
-      :name="name"
-      :pattern="pattern"
-      :placeholder="placeholder"
-      :readonly="readonly"
-      :disabled="disabled"
-      v-model="currentValue"
-      @focus="focusHandler"
-      @blur="onBlur"
-      @keyup="onKeyUp"
-      ref="input"/>
+        :id="`vux-x-input-${uuid}`"
+        v-if="type === 'tel'"
+        class="weui-input"
+        :maxlength="max"
+        :autocomplete="autocomplete"
+        :autocapitalize="autocapitalize"
+        :autocorrect="autocorrect"
+        :spellcheck="spellcheck"
+        :style="inputStyle"
+        type="tel"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :disabled="disabled"
+        v-model="currentValue"
+        @focus="focusHandler"
+        @blur="onBlur"
+        @keyup="onKeyUp"
+        ref="input"/>
     </div>
     <div class="weui-cell__ft">
       <icon type="clear" v-show="!hasRightFullHeightSlot && !equalWith && showClear && currentValue !== '' && !readonly && !disabled && isFocus" @click.native="clear"></icon>
@@ -139,484 +139,489 @@
     </div>
 
     <toast
-    v-model="showErrorToast"
-    type="text"
-    width="auto"
-    :time="600">{{ firstError }}</toast>
+      v-model="showErrorToast"
+      type="text"
+      width="auto"
+      :time="600">{{ firstError }}</toast>
   </div>
 </template>
 
 <script>
-import Base from '../../libs/base'
-import Icon from '../icon'
-import Toast from '../toast'
-import InlineDesc from '../inline-desc'
+  import Base from '../../libs/base'
+  import Icon from '../icon'
+  import Toast from '../toast'
+  import InlineDesc from '../inline-desc'
 
-import isEmail from 'validator/lib/isEmail'
-import isMobilePhone from 'validator/lib/isMobilePhone'
+  import isEmail from 'validator/lib/isEmail'
+  import isMobilePhone from 'validator/lib/isMobilePhone'
 
-import Debounce from '../../tools/debounce'
+  import Debounce from '../../tools/debounce'
 
-import mask from 'vanilla-masker'
+  import mask from 'vanilla-masker'
 
-const validators = {
-  'email': {
-    fn: isEmail,
-    msg: '邮箱格式'
-  },
-  'china-mobile': {
-    fn (str) {
-      return isMobilePhone(str, 'zh-CN')
+  const validators = {
+    'email': {
+      fn: isEmail,
+      msg: '邮箱格式'
     },
-    msg: '手机号码'
-  },
-  'china-name': {
-    fn (str) {
-      return str.length >= 2 && str.length <= 6
+    'china-mobile': {
+      fn (str) {
+        return isMobilePhone(str, 'zh-CN')
+      },
+      msg: '手机号码'
     },
-    msg: '中文姓名'
+    'china-name': {
+      fn (str) {
+        return str.length >= 2 && str.length <= 6
+      },
+      msg: '中文姓名'
+    }
   }
-}
-export default {
-  name: 'x-input',
-  created () {
-    this.currentValue = (this.value === undefined || this.value === null) ? '' : (this.mask ? this.maskValue(this.value) : this.value)
-    /* istanbul ignore if */
-    if (process.env.NODE_ENV === 'development') {
-      if (!this.title && !this.placeholder && !this.currentValue) {
-        console.warn('no title and no placeholder?')
-      }
-    }
-
-    if (this.required && (typeof this.currentValue === 'undefined' || this.currentValue === '')) {
-      this.valid = false
-    }
-    this.handleChangeEvent = true
-    if (this.debounce) {
-      this._debounce = Debounce(() => {
-        this.$emit('on-change', this.currentValue)
-      }, this.debounce)
-    }
-  },
-  beforeMount () {
-    if (this.$slots && this.$slots['restricted-label']) {
-      this.hasRestrictedLabel = true
-    }
-    if (this.$slots && this.$slots['right-full-height']) {
-      this.hasRightFullHeightSlot = true
-    }
-  },
-  beforeDestroy () {
-    if (this._debounce) {
-      this._debounce.cancel()
-    }
-    window.removeEventListener('resize', this.scrollIntoView)
-  },
-  mixins: [Base],
-  components: {
-    Icon,
-    InlineDesc,
-    Toast
-  },
-  props: {
-    title: {
-      type: String,
-      default: ''
-    },
-    type: {
-      type: String,
-      default: 'text'
-    },
-    placeholder: String,
-    value: [String, Number],
-    name: String,
-    readonly: Boolean,
-    disabled: Boolean,
-    keyboard: String,
-    inlineDesc: String,
-    isType: [String, Function],
-    min: Number,
-    max: Number,
-    showClear: {
-      type: Boolean,
-      default: true
-    },
-    equalWith: String,
-    textAlign: String,
-    // https://github.com/yisibl/blog/issues/3
-    autocomplete: {
-      type: String,
-      default: 'off'
-    },
-    autocapitalize: {
-      type: String,
-      default: 'off'
-    },
-    autocorrect: {
-      type: String,
-      default: 'off'
-    },
-    spellcheck: {
-      type: String,
-      default: 'false'
-    },
-    novalidate: {
-      type: Boolean,
-      default: false
-    },
-    iconType: String,
-    debounce: Number,
-    placeholderAlign: String,
-    labelWidth: String,
-    mask: String,
-    shouldToastError: {
-      type: Boolean,
-      default: true
-    }
-  },
-  computed: {
-    labelStyles () {
-      return {
-        width: this.labelWidthComputed || this.$parent.labelWidth || this.labelWidthComputed,
-        textAlign: this.$parent.labelAlign,
-        marginRight: this.$parent.labelMarginRight
-      }
-    },
-    labelClass () {
-      return {
-        'vux-cell-justify': this.$parent.labelAlign === 'justify' || this.$parent.$parent.labelAlign === 'justify'
-      }
-    },
-    pattern () {
-      if (this.keyboard === 'number' || this.isType === 'china-mobile') {
-        return '[0-9]*'
-      }
-    },
-    labelWidthComputed () {
-      const width = this.title.replace(/[^x00-xff]/g, '00').length / 2 + 1
-      if (width < 10) {
-        return width + 'em'
-      }
-    },
-    hasErrors () {
-      return Object.keys(this.errors).length > 0
-    },
-    inputStyle () {
-      if (this.textAlign) {
-        return {
-          textAlign: this.textAlign
+  export default {
+    name: 'x-input',
+    created () {
+      this.currentValue = (this.value === undefined || this.value === null) ? '' : (this.mask ? this.maskValue(this.value) : this.value)
+      /* istanbul ignore if */
+      if (process.env.NODE_ENV === 'development') {
+        if (!this.title && !this.placeholder && !this.currentValue) {
+          console.warn('no title and no placeholder?')
         }
       }
-    },
-    showWarn () {
-      return !this.novalidate && !this.equalWith && !this.valid && this.firstError && (this.touched || this.forceShowError)
-    }
-  },
-  mounted () {
-    window.addEventListener('resize', this.scrollIntoView)
-  },
-  methods: {
-    scrollIntoView (time = 0) {
-      // alert('scroll into view')
-      if (/iphone/i.test(navigator.userAgent)) {
-        // return
-      }
-      if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
-        // alert('will scroll')
-        setTimeout(() => {
-          // alert(this.$refs.input.length)
-          this.$refs.input.scrollIntoViewIfNeeded(true)
-        }, time)
-      }
-    },
-    onClickErrorIcon () {
-      if (this.shouldToastError && this.firstError) {
-        this.showErrorToast = true
-      }
-      this.$emit('on-click-error-icon', this.firstError)
-    },
-    maskValue (val) {
-      const val1 = this.mask ? mask.toPattern(val, this.mask) : val
-      return val1
-    },
-    reset (value = '') {
-      this.dirty = false
-      this.currentValue = value
-      this.firstError = ''
-      this.valid = true
-    },
-    clear () {
-      this.currentValue = ''
-      this.focus()
-      this.$emit('on-click-clear-icon')
-    },
-    focus () {
-      this.$refs.input.focus()
-    },
-    blur () {
-      this.$refs.input.blur()
-    },
-    focusHandler ($event) {
-      this.$emit('on-focus', this.currentValue, $event)
-      this.isFocus = true
-      // this.scrollIntoView(500)
-      // this.scrollIntoView(5000)
-      setTimeout(() => {
-        this.$refs.input.scrollIntoViewIfNeeded(false)
-        // this.$refs.input.scrollIntoViewIfNeeded()
-      }, 1000)
-      // $event.target.
-    },
-    onBlur ($event) {
-      this.setTouched()
-      this.validate()
-      this.isFocus = false
-      this.$emit('on-blur', this.currentValue, $event)
-    },
-    onKeyUp (e) {
-      if (e.key === 'Enter') {
-        e.target.blur()
-        this.$emit('on-enter', this.currentValue, e)
-      }
-    },
-    getError () {
-      let key = Object.keys(this.errors)[0]
-      this.firstError = this.errors[key]
-    },
-    validate () {
-      if (typeof this.equalWith !== 'undefined') {
-        this.validateEqual()
-        return
-      }
-      this.errors = {}
 
-      if (!this.currentValue && !this.required) {
-        this.valid = true
-        return
-      }
-
-      if (!this.currentValue && this.required) {
+      if (this.required && (typeof this.currentValue === 'undefined' || this.currentValue === '')) {
         this.valid = false
-        this.errors.required = '必填哦'
-        this.getError()
-        return
       }
-
-      if (typeof this.isType === 'string') {
-        const validator = validators[this.isType]
-        if (validator) {
-          let value = this.currentValue
-
-          if (this.isType === 'china-mobile' && this.mask === '999 9999 9999') {
-            value = this.currentValue.replace(/\s+/g, '')
+      this.handleChangeEvent = true
+      if (this.debounce) {
+        this._debounce = Debounce(() => {
+          this.$emit('on-change', this.currentValue)
+        }, this.debounce)
+      }
+    },
+    beforeMount () {
+      if (this.$slots && this.$slots['restricted-label']) {
+        this.hasRestrictedLabel = true
+      }
+      if (this.$slots && this.$slots['right-full-height']) {
+        this.hasRightFullHeightSlot = true
+      }
+    },
+    beforeDestroy () {
+      if (this._debounce) {
+        this._debounce.cancel()
+      }
+      window.removeEventListener('resize', this.scrollIntoView)
+    },
+    mixins: [Base],
+    components: {
+      Icon,
+      InlineDesc,
+      Toast
+    },
+    props: {
+      title: {
+        type: String,
+        default: ''
+      },
+      type: {
+        type: String,
+        default: 'text'
+      },
+      placeholder: String,
+      value: [String, Number],
+      name: String,
+      readonly: Boolean,
+      disabled: Boolean,
+      keyboard: String,
+      inlineDesc: String,
+      isType: [String, Function],
+      min: Number,
+      max: Number,
+      showClear: {
+        type: Boolean,
+        default: true
+      },
+      equalWith: String,
+      textAlign: String,
+      // https://github.com/yisibl/blog/issues/3
+      autocomplete: {
+        type: String,
+        default: 'off'
+      },
+      autocapitalize: {
+        type: String,
+        default: 'off'
+      },
+      autocorrect: {
+        type: String,
+        default: 'off'
+      },
+      spellcheck: {
+        type: String,
+        default: 'false'
+      },
+      novalidate: {
+        type: Boolean,
+        default: false
+      },
+      iconType: String,
+      debounce: Number,
+      placeholderAlign: String,
+      labelWidth: String,
+      mask: String,
+      shouldToastError: {
+        type: Boolean,
+        default: true
+      }
+    },
+    computed: {
+      labelStyles () {
+        return {
+          width: this.labelWidthComputed || this.$parent.labelWidth || this.labelWidthComputed,
+          textAlign: this.$parent.labelAlign,
+          marginRight: this.$parent.labelMarginRight
+        }
+      },
+      labelClass () {
+        return {
+          'vux-cell-justify': this.$parent.labelAlign === 'justify' || this.$parent.$parent.labelAlign === 'justify'
+        }
+      },
+      pattern () {
+        if (this.keyboard === 'number' || this.isType === 'china-mobile') {
+          return '[0-9]*'
+        }
+      },
+      labelWidthComputed () {
+        const width = this.title.replace(/[^x00-xff]/g, '00').length / 2 + 1
+        if (width < 10) {
+          return width + 'em'
+        }
+      },
+      hasErrors () {
+        return Object.keys(this.errors).length > 0
+      },
+      inputStyle () {
+        if (this.textAlign) {
+          return {
+            textAlign: this.textAlign
           }
+        }
+      },
+      showWarn () {
+        return !this.novalidate && !this.equalWith && !this.valid && this.firstError && (this.touched || this.forceShowError)
+      }
+    },
+    mounted () {
+      window.addEventListener('resize', this.scrollIntoView)
+    },
+    methods: {
+      scrollIntoView (time = 0) {
+        // alert('scroll into view')
+        if (/iphone/i.test(navigator.userAgent)) {
+          // return
+        }
+        if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
+          // alert('will scroll')
+          setTimeout(() => {
+            // alert(this.$refs.input.length)
+            this.$refs.input.scrollIntoViewIfNeeded(true)
+          }, time)
+        }
+      },
+      onClickErrorIcon () {
+        if (this.shouldToastError && this.firstError) {
+          this.showErrorToast = true
+        }
+        this.$emit('on-click-error-icon', this.firstError)
+      },
+      maskValue (val) {
+        const val1 = this.mask ? mask.toPattern(val, this.mask) : val
+        return val1
+      },
+      reset (value = '') {
+        this.dirty = false
+        this.currentValue = value
+        this.firstError = ''
+        this.valid = true
+      },
+      clear () {
+        this.currentValue = ''
+        this.focus()
+        this.$emit('on-click-clear-icon')
+      },
+      focus () {
+        this.$refs.input.focus()
+      },
+      blur () {
+        this.$refs.input.blur()
+      },
+      focusHandler ($event) {
+        this.$emit('on-focus', this.currentValue, $event)
+        this.isFocus = true
+        // this.scrollIntoView(500)
+        // this.scrollIntoView(5000)
+        setTimeout(() => {
+          this.$refs.input.scrollIntoViewIfNeeded(false)
+          // this.$refs.input.scrollIntoViewIfNeeded()
+        }, 1000)
+        // $event.target.
+      },
+      onBlur ($event) {
+        this.setTouched()
+        this.validate()
+        this.isFocus = false
+        this.$emit('on-blur', this.currentValue, $event)
+      },
+      onKeyUp (e) {
+        if (e.key === 'Enter') {
+          e.target.blur()
+          this.$emit('on-enter', this.currentValue, e)
+        }
+      },
+      getError () {
+        let key = Object.keys(this.errors)[0]
+        this.firstError = this.errors[key]
+      },
+      validate () {
+        if (typeof this.equalWith !== 'undefined') {
+          this.validateEqual()
+          return
+        }
+        this.errors = {}
 
-          this.valid = validator[ 'fn' ](value)
+        if (!this.currentValue && !this.required) {
+          this.valid = true
+          return
+        }
+
+        if (!this.currentValue && this.required) {
+          this.valid = false
+          this.errors.required = '必填哦'
+          this.getError()
+          return
+        }
+
+        if (typeof this.isType === 'string') {
+          const validator = validators[this.isType]
+          if (validator) {
+            let value = this.currentValue
+
+            if (this.isType === 'china-mobile' && this.mask === '999 9999 9999') {
+              value = this.currentValue.replace(/\s+/g, '')
+            }
+
+            this.valid = validator[ 'fn' ](value)
+            if (!this.valid) {
+              this.forceShowError = true
+              this.errors.format = validator[ 'msg' ] + '格式不对哦~'
+              this.getError()
+              return
+            } else {
+              delete this.errors.format
+            }
+          }
+        }
+
+        if (typeof this.isType === 'function') {
+          const validStatus = this.isType(this.currentValue)
+          this.valid = validStatus.valid
           if (!this.valid) {
+            this.errors.format = validStatus.msg
             this.forceShowError = true
-            this.errors.format = validator[ 'msg' ] + '格式不对哦~'
             this.getError()
             return
           } else {
             delete this.errors.format
           }
         }
-      }
 
-      if (typeof this.isType === 'function') {
-        const validStatus = this.isType(this.currentValue)
-        this.valid = validStatus.valid
-        if (!this.valid) {
-          this.errors.format = validStatus.msg
-          this.forceShowError = true
-          this.getError()
+        if (this.min) {
+          if (this.currentValue.length < this.min) {
+            this.errors.min = `最少应该输入${this.min}个字符哦`
+            this.valid = false
+            this.getError()
+            return
+          } else {
+            delete this.errors.min
+          }
+        }
+
+        if (this.max) {
+          if (this.currentValue.length > this.max) {
+            this.errors.max = `最多可以输入${this.max}个字符哦`
+            this.valid = false
+            this.forceShowError = true
+            return
+          } else {
+            this.forceShowError = false
+            delete this.errors.max
+          }
+        }
+
+        this.valid = true
+      },
+      validateEqual () {
+        if (!this.equalWith && this.currentValue) {
+          this.valid = false
+          this.errors.equal = '输入不一致'
+          return
+        }
+        let willCheck = this.dirty || this.currentValue.length >= this.equalWith.length
+        // 只在长度符合时显示正确与否
+        if (willCheck && this.currentValue !== this.equalWith) {
+          this.valid = false
+          this.errors.equal = '输入不一致'
           return
         } else {
-          delete this.errors.format
+          if (!this.currentValue && this.required) {
+            this.valid = false
+          } else {
+            this.valid = true
+            delete this.errors.equal
+          }
         }
-      }
-
-      if (this.min) {
-        if (this.currentValue.length < this.min) {
-          this.errors.min = `最少应该输入${this.min}个字符哦`
-          this.valid = false
-          this.getError()
-          return
-        } else {
-          delete this.errors.min
+      },
+      // #2810
+      _getInputMaskSelection (selection, direction, maskVal, loop) {
+        if (!this.mask || (loop && direction === 0)) {
+          return selection
         }
-      }
-
-      if (this.max) {
-        if (this.currentValue.length > this.max) {
-          this.errors.max = `最多可以输入${this.max}个字符哦`
-          this.valid = false
-          this.forceShowError = true
-          return
-        } else {
-          this.forceShowError = false
-          delete this.errors.max
+        if (direction === 0) {
+          direction = this.lastDirection
         }
-      }
-
-      this.valid = true
-    },
-    validateEqual () {
-      if (!this.equalWith && this.currentValue) {
-        this.valid = false
-        this.errors.equal = '输入不一致'
-        return
-      }
-      let willCheck = this.dirty || this.currentValue.length >= this.equalWith.length
-      // 只在长度符合时显示正确与否
-      if (willCheck && this.currentValue !== this.equalWith) {
-        this.valid = false
-        this.errors.equal = '输入不一致'
-        return
-      } else {
-        if (!this.currentValue && this.required) {
-          this.valid = false
-        } else {
-          this.valid = true
-          delete this.errors.equal
+        if (direction > 0) {
+          const maskChar = this.mask.substr(selection - direction, 1)
+          if (!maskChar.match(/[9SA]/)) {
+            return this._getInputMaskSelection(selection + 1, direction, maskVal, true)
+          }
         }
-      }
-    },
-    // #2810
-    _getInputMaskSelection (selection, direction, maskVal, loop) {
-      if (!this.mask || (loop && direction === 0)) {
         return selection
       }
-      if (direction === 0) {
-        direction = this.lastDirection
+    },
+    data () {
+      return {
+        hasRightFullHeightSlot: false,
+        hasRestrictedLabel: false,
+        firstError: '',
+        forceShowError: false,
+        hasLengthEqual: false,
+        valid: true,
+        currentValue: '',
+        showErrorToast: false,
+        isFocus: false
       }
-      if (direction > 0) {
-        const maskChar = this.mask.substr(selection - direction, 1)
-        if (!maskChar.match(/[9SA]/)) {
-          return this._getInputMaskSelection(selection + 1, direction, maskVal, true)
+    },
+    watch: {
+      mask (val) {
+        if (val && this.currentValue) {
+          this.currentValue = this.maskValue(this.currentValue)
         }
-      }
-      return selection
-    }
-  },
-  data () {
-    return {
-      hasRightFullHeightSlot: false,
-      hasRestrictedLabel: false,
-      firstError: '',
-      forceShowError: false,
-      hasLengthEqual: false,
-      valid: true,
-      currentValue: '',
-      showErrorToast: false,
-      isFocus: false
-    }
-  },
-  watch: {
-    mask (val) {
-      if (val && this.currentValue) {
-        this.currentValue = this.maskValue(this.currentValue)
-      }
-    },
-    valid () {
-      this.getError()
-    },
-    value (val) {
-      this.currentValue = val
-    },
-    equalWith (newVal) {
-      if (newVal && this.equalWith) {
-        if (newVal.length === this.equalWith.length) {
-          this.hasLengthEqual = true
+      },
+      valid () {
+        this.getError()
+      },
+      value (val) {
+        this.currentValue = val
+      },
+      equalWith (newVal) {
+        if (newVal && this.equalWith) {
+          if (newVal.length === this.equalWith.length) {
+            this.hasLengthEqual = true
+          }
+          this.validateEqual()
+        } else {
+          this.validate()
         }
-        this.validateEqual()
-      } else {
-        this.validate()
-      }
-    },
-    currentValue (newVal, oldVal) {
-      if (!this.equalWith && newVal) {
-        this.validateEqual()
-      }
-      if (newVal && this.equalWith) {
-        if (newVal.length === this.equalWith.length) {
-          this.hasLengthEqual = true
+      },
+      currentValue (newVal, oldVal) {
+        let selection = null
+        if (!this.equalWith && newVal) {
+          this.validateEqual()
         }
-        this.validateEqual()
-      } else {
-        this.validate()
-      }
+        if (newVal && this.equalWith) {
+          if (newVal.length === this.equalWith.length) {
+            this.hasLengthEqual = true
+          }
+          this.validateEqual()
+        } else {
+          this.validate()
+        }
+        // #2960
+        try {
+          selection = this.$refs.input.selectionStart
+          let direction = newVal.length - oldVal.length
+          selection = this._getInputMaskSelection(selection, direction, this.maskValue(newVal))
+          this.lastDirection = direction
+        } catch (e) {
 
-      let selection = this.$refs.input.selectionStart
-      let direction = newVal.length - oldVal.length
-      selection = this._getInputMaskSelection(selection, direction, this.maskValue(newVal))
-      this.lastDirection = direction
-      this.$emit('input', this.maskValue(newVal))
-      // #2810
-      this.$nextTick(() => {
-        if (this.$refs.input.selectionStart !== selection) {
-          this.$refs.input.selectionStart = selection
-          this.$refs.input.selectionEnd = selection
         }
-        if (this.currentValue !== this.maskValue(newVal)) {
-          this.currentValue = this.maskValue(newVal)
-        }
-      })
+        this.$emit('input', this.maskValue(newVal))
+        // #2810
+        this.$nextTick(() => {
+          if (this.$refs.input.selectionStart !== selection) {
+            this.$refs.input.selectionStart = selection
+            this.$refs.input.selectionEnd = selection
+          }
+          if (this.currentValue !== this.maskValue(newVal)) {
+            this.currentValue = this.maskValue(newVal)
+          }
+        })
 
-      if (this._debounce) {
-        this._debounce()
-      } else {
-        this.$emit('on-change', newVal)
+        if (this._debounce) {
+          this._debounce()
+        } else {
+          this.$emit('on-change', newVal)
+        }
       }
     }
   }
-}
 </script>
 
 <style lang="less">
-@import '../../styles/weui/widget/weui_cell/weui_access';
-@import '../../styles/weui/widget/weui_cell/weui_cell_global';
-@import '../../styles/weui/widget/weui_cell/weui_form/weui_form_common';
-@import '../../styles/weui/widget/weui_cell/weui_form/weui_vcode';
+  @import '../../styles/weui/widget/weui_cell/weui_access';
+  @import '../../styles/weui/widget/weui_cell/weui_cell_global';
+  @import '../../styles/weui/widget/weui_cell/weui_form/weui_form_common';
+  @import '../../styles/weui/widget/weui_cell/weui_form/weui_vcode';
 
-.vux-x-input .vux-x-input-placeholder-right input::-webkit-input-placeholder {
-  text-align: right;
-}
-.vux-x-input .vux-x-input-placeholder-center input::-webkit-input-placeholder {
-  text-align: center;
-}
-.vux-x-input .vux-input-icon {
-  font-size: 21px;
-}
-.vux-input-icon.weui-icon-warn:before, .vux-input-icon.weui-icon-success:before {
-  font-size: 21px;
-}
-.vux-x-input .weui-icon {
-  padding-left: 5px;
-}
-.vux-x-input.weui-cell_vcode {
-  padding-top: 0;
-  padding-right: 0;
-  padding-bottom: 0;
-}
-.vux-x-input.disabled {
-  .weui-input {
-    text-fill-color: #888;
-    -webkit-text-fill-color: #888; /* Override iOS / Android font color change */
-    opacity: 1; /* Override iOS opacity change affecting text & background color */
+  .vux-x-input .vux-x-input-placeholder-right input::-webkit-input-placeholder {
+    text-align: right;
   }
-}
-.vux-x-input-right-full {
-  margin-left: 5px;
-  height: @weuiCellHeight;
-  vertical-align: middle;
-	& img {
-		height: @weuiCellHeight;
-	}
-}
-.vux-x-input-has-right-full {
-  padding-top: 0;
-  padding-right: 0;
-  padding-bottom: 0;
-}
+  .vux-x-input .vux-x-input-placeholder-center input::-webkit-input-placeholder {
+    text-align: center;
+  }
+  .vux-x-input .vux-input-icon {
+    font-size: 21px;
+  }
+  .vux-input-icon.weui-icon-warn:before, .vux-input-icon.weui-icon-success:before {
+    font-size: 21px;
+  }
+  .vux-x-input .weui-icon {
+    padding-left: 5px;
+  }
+  .vux-x-input.weui-cell_vcode {
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+  }
+  .vux-x-input.disabled {
+    .weui-input {
+      text-fill-color: #888;
+      -webkit-text-fill-color: #888; /* Override iOS / Android font color change */
+      opacity: 1; /* Override iOS opacity change affecting text & background color */
+    }
+  }
+  .vux-x-input-right-full {
+    margin-left: 5px;
+    height: @weuiCellHeight;
+    vertical-align: middle;
+    & img {
+      height: @weuiCellHeight;
+    }
+  }
+  .vux-x-input-has-right-full {
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 </style>

--- a/src/demo_list.json
+++ b/src/demo_list.json
@@ -81,6 +81,7 @@
   "Issue624#/issue/624",
   "Issue649#/issue/649",
   "Issue865#/issue/865",
+  "Issue2960#/issue/2960",
   "Swipeout",
   "TabbarSimple",
   "Device#/plugin/device",

--- a/src/demos/Issue2960.vue
+++ b/src/demos/Issue2960.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <group title="check if value is valid when required===false">
+      <x-input type="number" v-model="currentValue"></x-input>
+      <h1>{{currentValue}}</h1>
+    </group>
+    <!--
+
+      目前唯一允许安全选择文本的元素是：
+      <input type="text|search|password|tel|url">如下所述：
+      https://stackoverflow.com/questions/21177489/selectionstart-selectionend-on-input-type-number-no-longer-allowed-in-chrome
+
+    -->
+  </div>
+</template>
+
+<script>
+  import { XInput, Group, XButton, Cell } from 'vux'
+  export default {
+    components: {
+      XInput,
+      XButton,
+      Group,
+      Cell
+    },
+    name: 'Issue2960',
+    data () {
+      return {
+        currentValue: 0
+      }
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
#2960 
经过测试发现的原因，是 `input.selectionStart` 在 `type` 为 `number`的时候部分浏览器不允许选择，所以报错触发不了 `$emit('input')`。
![39172193254158860.jpg](https://i.loli.net/2018/09/04/5b8de7bd919e2.jpg)
 > 目前唯一允许安全选择文本的元素是：
<input type="text|search|password|tel|url">如下所述：
参考
> https://stackoverflow.com/questions/21177489/selectionstart-selectionend-on-input-type-number-no-longer-allowed-in-chrome

