### PR TITLE
#2960 修复x-input type =number 在安卓部分浏览器下 v-model 绑定无效的bug

### DIFF
--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -535,6 +535,7 @@ export default {
       }
     },
     currentValue (newVal, oldVal) {
+      let selection = null
       if (!this.equalWith && newVal) {
         this.validateEqual()
       }
@@ -546,11 +547,13 @@ export default {
       } else {
         this.validate()
       }
-
-      let selection = this.$refs.input.selectionStart
-      let direction = newVal.length - oldVal.length
-      selection = this._getInputMaskSelection(selection, direction, this.maskValue(newVal))
-      this.lastDirection = direction
+      // #2960
+      try {
+        selection = this.$refs.input.selectionStart
+        let direction = newVal.length - oldVal.length
+        selection = this._getInputMaskSelection(selection, direction, this.maskValue(newVal))
+        this.lastDirection = direction
+      } catch (e) {}
       this.$emit('input', this.maskValue(newVal))
       // #2810
       this.$nextTick(() => {

--- a/src/demo_list.json
+++ b/src/demo_list.json
@@ -81,6 +81,7 @@
   "Issue624#/issue/624",
   "Issue649#/issue/649",
   "Issue865#/issue/865",
+  "Issue2960#/issue/2960",
   "Swipeout",
   "TabbarSimple",
   "Device#/plugin/device",

--- a/src/demos/Issue2960.vue
+++ b/src/demos/Issue2960.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <group title="check if value is valid when required===false">
+      <x-input type="number" v-model="currentValue"></x-input>
+      <h1>{{currentValue}}</h1>
+    </group>
+    <!--
+
+      目前唯一允许安全选择文本的元素是：
+      <input type="text|search|password|tel|url">如下所述：
+      https://stackoverflow.com/questions/21177489/selectionstart-selectionend-on-input-type-number-no-longer-allowed-in-chrome
+
+    -->
+  </div>
+</template>
+
+<script>
+  import { XInput, Group, XButton, Cell } from 'vux'
+  export default {
+    components: {
+      XInput,
+      XButton,
+      Group,
+      Cell
+    },
+    name: 'Issue2960',
+    data () {
+      return {
+        currentValue: 0
+      }
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
#2960  #2857 
经过测试发现的原因，是 `input.selectionStart` 在 `type` 为 `number`的时候部分浏览器不允许选择，所以报错触发不了 `$emit('input')`。
![39172193254158860.jpg](https://i.loli.net/2018/09/04/5b8de7bd919e2.jpg)
 目前唯一允许安全选择文本的元素是： text|search|password|tel|url
<input type="text|search|password|tel|url">如下所述：
参考
> https://stackoverflow.com/questions/21177489/selectionstart-selectionend-on-input-type-number-no-longer-allowed-in-chrome