### PR TITLE
fix:修复v-bind:class={}时，导致p标签产生一个空的class属性，将return {}更换为return null

### DIFF
--- a/src/components/datetime/index.vue
+++ b/src/components/datetime/index.vue
@@ -178,7 +178,7 @@ export default {
   computed: {
     styles () {
       if (!this.$parent) {
-        return {}
+        return null
       }
       return {
         width: this.$parent.labelWidth,
@@ -259,7 +259,7 @@ export default {
     },
     labelClass () {
       if (!this.$parent) {
-        return {}
+        return null
       }
       return {
         'vux-cell-justify': this.$parent.labelAlign === 'justify' || this.$parent.$parent.labelAlign === 'justify'

--- a/src/styles/variable.less
+++ b/src/styles/variable.less
@@ -478,8 +478,8 @@
 * toast
 */
 /**
-* en: text color of content
-* zh-CN: 内容文本颜色
+* en: text size of content
+* zh-CN: 内容文本大小
 */
 @toast-content-font-size: 16px;
 /**


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors

在datetime组件中，有这样一段代码`<p :style="styles" :class="labelClass" v-html="title"></p> `，当 !this.$parent 成立时，styles的值为{},会导致生成一个带有空class属性的p标签：`<p class> </p>`，将return {}改为return null,就可以修复这个问题。