### PR TITLE
自动将%D转换%H

### DIFF
--- a/src/components/clocker/clocker.js
+++ b/src/components/clocker/clocker.js
@@ -67,7 +67,7 @@ function strftime (offsetObject) {
         var plural = directive[3] || ''
         var value = null
         // Get the key
-        var key
+        var key = null
         directive = directive[2]
         // Swap shot-versions directives
         if (DIRECTIVE_KEY_MAP.hasOwnProperty(directive)) {

--- a/src/components/clocker/clocker.js
+++ b/src/components/clocker/clocker.js
@@ -67,11 +67,15 @@ function strftime (offsetObject) {
         var plural = directive[3] || ''
         var value = null
         // Get the key
+        var key
         directive = directive[2]
         // Swap shot-versions directives
         if (DIRECTIVE_KEY_MAP.hasOwnProperty(directive)) {
-          value = DIRECTIVE_KEY_MAP[directive]
-          value = Number(offsetObject[value])
+          key = DIRECTIVE_KEY_MAP[directive]
+          value = Number(offsetObject[key])
+          if (i === 0 && key === 'hours') {
+            value += Number(offsetObject['days']) * 24
+          }
         }
         if (value !== null) {
           // Pluralize

--- a/src/components/clocker/clocker.js
+++ b/src/components/clocker/clocker.js
@@ -59,6 +59,10 @@ function escapedRegExp (str) {
 function strftime (offsetObject) {
   return function (format) {
     var directives = format.match(/%(-|!)?[A-Z]{1}(:[^]+)?/gi)
+    var d2h = false
+    if (directives.indexOf('%D') < 0 && directives.indexOf('%H') >= 0) {
+      d2h = true
+    }
     if (directives) {
       for (var i = 0, len = directives.length; i < len; ++i) {
         var directive = directives[i].match(/%(-|!)?([a-zA-Z]{1})(:[^]+)?/)
@@ -66,14 +70,14 @@ function strftime (offsetObject) {
         var modifier = directive[1] || ''
         var plural = directive[3] || ''
         var value = null
-        // Get the key
         var key = null
+        // Get the key
         directive = directive[2]
         // Swap shot-versions directives
         if (DIRECTIVE_KEY_MAP.hasOwnProperty(directive)) {
           key = DIRECTIVE_KEY_MAP[directive]
           value = Number(offsetObject[key])
-          if (i === 0 && key === 'hours') {
+          if (key === 'hours' && d2h) {
             value += Number(offsetObject['days']) * 24
           }
         }


### PR DESCRIPTION

Fixes  #2931 

clocker的格式输出中，如果没有请求%D，且有days，自动将days转换为hours输出

Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors
