### PR TITLE
fix: texearea newlines

### DIFF
--- a/src/components/x-textarea/index.vue
+++ b/src/components/x-textarea/index.vue
@@ -115,8 +115,17 @@ export default {
       this.currentValue = val
     },
     currentValue (newVal) {
-      if (this.max && newVal && newVal.length > this.max) {
-        this.currentValue = newVal.slice(0, this.max)
+      if (this.max && newVal) {
+        let len = newVal.replace(/\n/g, 'aa').length
+        if (len > this.max) {
+          let newLines = newVal.match(/\n/g).length
+          this.currentValue = newVal.slice(0, this.max - newLines)
+          this.$nextTick(() => {
+            if (this.autosize) {
+              this.updateAutosize()
+            }
+          })
+        }
       }
       this.$emit('input', this.currentValue)
       this.$emit('on-change', this.currentValue)


### PR DESCRIPTION
修复 texearea 在换行时统计字数异常行为：
运行时 count 计算属性把 '\n' 算两个字符，但是在监听 currentValue 时并没有，导致存在换行的情况下就算已经达到最大限制仍然能够输入。