### PR TITLE
When the width of the tab is not the width of the screen, there will …

### DIFF
--- a/src/components/tab/tab.vue
+++ b/src/components/tab/tab.vue
@@ -67,13 +67,17 @@ export default {
   computed: {
     barLeft () {
       if (this.hasReady) {
-        const count = this.scrollable ? (window.innerWidth / this.$children[this.currentIndex || 0].$el.getBoundingClientRect().width) : this.number
+        const count = this.scrollable
+          ? (this.$el.getBoundingClientRect().width / this.$children[this.currentIndex || 0].$el.getBoundingClientRect().width)
+          : this.number
         return `${this.currentIndex * (100 / count)}%`
       }
     },
     barRight () {
       if (this.hasReady) {
-        const count = this.scrollable ? (window.innerWidth / this.$children[this.currentIndex || 0].$el.getBoundingClientRect().width) : this.number
+        const count = this.scrollable
+          ? (this.$el.getBoundingClientRect().width / this.$children[this.currentIndex || 0].$el.getBoundingClientRect().width)
+          : this.number
         return `${(count - this.currentIndex - 1) * (100 / count)}%`
       }
     },


### PR DESCRIPTION
…be some problems with the line below, and the width is calculated using the width of the parent container.

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
