### PR TITLE
bug fix:  魅族手机某型号拿不到系统语言

### DIFF
--- a/src/plugins/locale/index.js
+++ b/src/plugins/locale/index.js
@@ -25,7 +25,7 @@ const locale = function (options = {}) {
         return this.defaultLocal
       }
 
-      return navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage)
+      return navigator.languages && navigator.languages.length ? navigator.languages[0] : (navigator.language || navigator.userLanguage)
     },
     set: function (locale) {
       if (this.storageList.indexOf('cookie') > -1) {


### PR DESCRIPTION
魅族手机 navigator.languages 为空数组，拿不到系统语言，增加 && navigator.languages.length判断条件，可解决此bug

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
