### PR TITLE
fix <Radio> 组件在options为key/value时，选择子项时，fillMode 的值没有被清空。

### DIFF
--- a/src/components/radio/index.vue
+++ b/src/components/radio/index.vue
@@ -80,7 +80,7 @@ export default {
 function contains (a, obj) {
   var i = a.length
   while (i--) {
-    if (a[i] === obj) {
+    if (getKey(a[i]) === obj) {
       return true
     }
   }


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
