### PR TITLE
Update x-address

### DIFF
--- a/src/components/x-address/index.vue
+++ b/src/components/x-address/index.vue
@@ -1,7 +1,7 @@
 <template>
   <popup-picker
     :fixed-columns="hideDistrict ? 2 : 0"
-    :columns="3"
+    :columns="columns"
     :data="list"
     :title="title"
     v-model="currentValue"
@@ -54,6 +54,12 @@ export default {
       type: Array,
       default () {
         return []
+      }
+    },
+    columns: {
+      type: Number,
+      default () {
+        return 3
       }
     },
     rawValue: Boolean,


### PR DESCRIPTION
props 添加 "columns" 属性，做国际化的时候发现，有可能会选择到国家，或者只选择到省市，所以觉得还是把 columns 暴露出去好，默认还是原来的3列

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
