### PR TITLE
fix: tab can't scroll to the right position

### DIFF
--- a/src/components/tab/tab.vue
+++ b/src/components/tab/tab.vue
@@ -133,11 +133,11 @@ export default {
       }
       const currentIndexTab = this.$children[this.currentIndex].$el
       let count = 0
+      const scrollDuration = 15
       // scroll animation
       const step = () => {
-        const scrollDuration = 15
         const nav = this.$refs.nav
-        nav.scrollLeft += (currentIndexTab.offsetLeft - (nav.offsetWidth - currentIndexTab.offsetWidth) / 2 - nav.scrollLeft) / scrollDuration
+        nav.scrollLeft += (currentIndexTab.offsetLeft - (nav.offsetWidth - currentIndexTab.offsetWidth) / 2 - nav.scrollLeft) / (scrollDuration - count)
         if (++count < scrollDuration) {
           window.requestAnimationFrame(step)
         }


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors

* 原来的代码会出现不能选中的tab滚动到container的中间位置的问题。
* 先假设在进行最后一次滚动前依然没有到达目标位置，距离设为delta，那么最后一次会只是滚动delta / 15，不能让delta归零。