### PR TITLE
解决在预览关闭状态下，删除图片列表中的图片导致报错的bug

### DIFF
--- a/src/components/previewer/index.vue
+++ b/src/components/previewer/index.vue
@@ -69,6 +69,11 @@ export default {
       })
     }
   },
+  data () {
+    return {
+      isOpen: false
+    }
+  }, 
   watch: {
     imgs (newVal, oldVal) {
       if (!this.photoswipe) {
@@ -82,9 +87,11 @@ export default {
         if (goToIndex > this.photoswipe.items.length - 1) {
           goToIndex = 0
         }
-        this.photoswipe.goTo(goToIndex)
-        this.photoswipe.updateSize(true)
-        this.photoswipe.ui.update()
+        if (this.isOpen) {
+          this.photoswipe.goTo(goToIndex)
+          this.photoswipe.updateSize(true)
+          this.photoswipe.ui.update()
+        }
       } else if (!newVal.length) {
         this.close()
       }
@@ -130,6 +137,7 @@ export default {
 
       this.photoswipe.init()
       this.photoswipe.listen('close', () => {
+        this.isOpen = false
         this.$emit('on-close')
       })
       this.photoswipe.listen('afterChange', (a, b) => {


### PR DESCRIPTION
如下图所示，我在图片列表中添加了删除按钮，在预览关闭状态下，先点开预览，再关闭预览，然后删除图片列表中的图片就会导致报错
![image](https://user-images.githubusercontent.com/3724780/80301659-e7820e00-87d7-11ea-8b01-0534e65b470f.png)


```
vue.esm.js?efeb:628 [Vue warn]: Error in callback for watcher "imgs": "TypeError: Cannot read property 'updateScrollOffset' of null"

found in

---> <Previewer> at node_modules/vux/src/components/previewer/index.vue
       <ImageUploader> at src/components/ui/ImageUploader.vue
         <CellBox> at node_modules/vux/src/components/cell-box/index.vue
           <Group> at node_modules/vux/src/components/group/index.vue
             <Edit> at src/pages/main/tel/Service/Edit.vue
               <App> at src/App.vue
                 <Root>
warn @ vue.esm.js?efeb:628
logError @ vue.esm.js?efeb:1893
globalHandleError @ vue.esm.js?efeb:1888
handleError @ vue.esm.js?efeb:1848
run @ vue.esm.js?efeb:4579
flushSchedulerQueue @ vue.esm.js?efeb:4319
(anonymous) @ vue.esm.js?efeb:1989
flushCallbacks @ vue.esm.js?efeb:1915
Promise.then (async)
timerFunc @ vue.esm.js?efeb:1942
nextTick @ vue.esm.js?efeb:1999
queueWatcher @ vue.esm.js?efeb:4411
update @ vue.esm.js?efeb:4553
notify @ vue.esm.js?efeb:739
reactiveSetter @ vue.esm.js?efeb:1064
proxySetter @ vue.esm.js?efeb:4640
callback @ ImageUploader.vue?4d88:24
invokeWithErrorHandling @ vue.esm.js?efeb:1863
invoker @ vue.esm.js?efeb:2188
invokeWithErrorHandling @ vue.esm.js?efeb:1863
Vue.$emit @ vue.esm.js?efeb:3897
emitInput @ vue-upload-component.js?d56b:1380
remove @ vue-upload-component.js?d56b:1287
click @ ImageUploader.vue?4d88:74
invokeWithErrorHandling @ vue.esm.js?efeb:1863
invoker @ vue.esm.js?efeb:2188
original._wrapper @ vue.esm.js?efeb:7565
vue.esm.js?efeb:1897 TypeError: Cannot read property 'updateScrollOffset' of null
    at _shout (photoswipe.js?8bb3:428)
    at PhotoSwipe.setScrollOffset (photoswipe.js?8bb3:798)
    at _updatePageScrollOffset (photoswipe.js?8bb3:704)
    at PhotoSwipe.updateSize (photoswipe.js?8bb3:1212)
    at VueComponent.imgs (index.vue?d853:92)
    at Watcher.run (vue.esm.js?efeb:4577)
    at flushSchedulerQueue (vue.esm.js?efeb:4319)
    at Array.eval (vue.esm.js?efeb:1989)
    at flushCallbacks (vue.esm.js?efeb:1915)
logError @ vue.esm.js?efeb:1897
globalHandleError @ vue.esm.js?efeb:1888
handleError @ vue.esm.js?efeb:1848
run @ vue.esm.js?efeb:4579
flushSchedulerQueue @ vue.esm.js?efeb:4319
(anonymous) @ vue.esm.js?efeb:1989
flushCallbacks @ vue.esm.js?efeb:1915
Promise.then (async)
timerFunc @ vue.esm.js?efeb:1942
nextTick @ vue.esm.js?efeb:1999
queueWatcher @ vue.esm.js?efeb:4411
update @ vue.esm.js?efeb:4553
notify @ vue.esm.js?efeb:739
reactiveSetter @ vue.esm.js?efeb:1064
proxySetter @ vue.esm.js?efeb:4640
callback @ ImageUploader.vue?4d88:24
invokeWithErrorHandling @ vue.esm.js?efeb:1863
invoker @ vue.esm.js?efeb:2188
invokeWithErrorHandling @ vue.esm.js?efeb:1863
Vue.$emit @ vue.esm.js?efeb:3897
emitInput @ vue-upload-component.js?d56b:1380
remove @ vue-upload-component.js?d56b:1287
click @ ImageUploader.vue?4d88:74
invokeWithErrorHandling @ vue.esm.js?efeb:1863
invoker @ vue.esm.js?efeb:2188
original._wrapper @ vue.esm.js?efeb:7565
```

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
