### PR TITLE
[bug fix]修复页面高度变化时，页面会滚动到最后一个x-input，而不是当前聚焦的input  

### DIFF
--- a/src/components/x-input/index.vue
+++ b/src/components/x-input/index.vue
@@ -210,7 +210,6 @@ export default {
     if (this._debounce) {
       this._debounce.cancel()
     }
-    window.removeEventListener('resize', this.scrollIntoView)
   },
   mixins: [Base],
   components: {
@@ -312,9 +311,6 @@ export default {
     showWarn () {
       return !this.novalidate && !this.equalWith && !this.valid && this.firstError && (this.touched || this.forceShowError)
     }
-  },
-  mounted () {
-    window.addEventListener('resize', this.scrollIntoView)
   },
   methods: {
     scrollIntoView (time = 0) {


### PR DESCRIPTION
Please makes sure the items are checked before submitting your PR, thank you!

* [x] `Rebase` before creating a PR to keep commit history clear.
* [x] `Only One commit`
* [x] No `eslint` errors

Fix: #3287
