### PR TITLE
解决v2.9.6修改x-dialog结构引起的Android低版本(5.1)弹框错位

### DIFF
--- a/src/styles/weui/widget/weui_tips/weui_dialog.less
+++ b/src/styles/weui/widget/weui_tips/weui_dialog.less
@@ -13,6 +13,9 @@
     border-radius: 3px;
     overflow: hidden;
 }
+.weui-mask .weui-dialog {
+    position: relative;
+}
 .weui-dialog__hd {
     padding: 1.3em @weuiDialogGapWidth .5em;
     &.with-no-content {


### PR DESCRIPTION
由于.weui-mask定位是position: fixed;修改结构后下级的.weui-dialog又是position: fixed;导致低版本浏览器弹框错位无法正常交互
