### PR TITLE
feat(checker): 增加 autoClear 属性以控制禁用时是否自动清空选中值

### DIFF
--- a/src/components/checker/checker-item.vue
+++ b/src/components/checker/checker-item.vue
@@ -16,7 +16,7 @@ export default {
   },
   watch: {
     disabled (val) {
-      if (val && this.$parent.type === 'radio' && this.value === this.$parent.currentValue) {
+      if (val && this.$parent.type === 'radio' && this.$parent.autoClear && this.value === this.$parent.currentValue) {
         this.$parent.currentValue = ''
       }
     }

--- a/src/components/checker/checker.vue
+++ b/src/components/checker/checker.vue
@@ -17,7 +17,11 @@ export default {
     },
     value: [String, Number, Array, Object],
     max: Number,
-    radioRequired: Boolean
+    radioRequired: Boolean,
+    autoClear: {
+      type: Boolean,
+      default: true,
+    }
   },
   watch: {
     value (newValue) {

--- a/src/components/checker/metas.yml
+++ b/src/components/checker/metas.yml
@@ -51,6 +51,11 @@ checker:
       default: false
       en: whether value is required in radio mode. if true, current selected item will always be selected even after clicking
       zh-CN: 在单选模式下是否必选一个值。设为 true 后点击当前选中项不会取消选中。
+    auto-clear:
+      type: Boolean
+      default: true
+      en: whether value is required in radio mode. if disabled is set to true, will the selected value be automatically cleared
+      zh-CN: 在单选模式下，将disabled设为true，是否自动清空已选值。
   events:
     on-change:
       params: '`(value)`'


### PR DESCRIPTION
新增 `autoClear` 属性，默认值为 true，用于在单选模式下当选项被禁用时，
控制是否自动清空当前选中的值。同时更新了相关逻辑以支持该功能。

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
